### PR TITLE
Use behind a proxy

### DIFF
--- a/auth/google/google_test.go
+++ b/auth/google/google_test.go
@@ -17,7 +17,7 @@ func TestAuthURLWithoutDomain(t *testing.T) {
 				ClientID:     "client_id",
 				ClientSecret: "client_secret",
 			},
-			Host: "foo.com",
+			Host: "foo.com:9090",
 		},
 		Port: 9090,
 	}

--- a/auth/okta/okta_test.go
+++ b/auth/okta/okta_test.go
@@ -18,7 +18,7 @@ func TestAuthURL(t *testing.T) {
 				ClientSecret: "client_secret",
 				BaseURL:      "https://oktapreview.com",
 			},
-			Host: "foo.com",
+			Host: "foo.com:9090",
 		},
 		Port: 9090,
 	}

--- a/config/context.go
+++ b/config/context.go
@@ -24,11 +24,7 @@ type membership struct {
 
 // Host is the normalized host URLs to the hub.
 func (c *Context) Host() string {
-	switch c.Port {
-	case 80, 443:
-		return c.Info.Host
-	}
-	return fmt.Sprintf("%s:%d", c.Info.Host, c.Port)
+	return c.Info.Host
 }
 
 // ListenAddr is the address that should be passed to net.Listen.


### PR DESCRIPTION
accept ENV Vars for oauth config, and change config for: scheme, host…, and port for use behind proxy

Squashed some commits to make it easier on PR to upstream.
Closing https://github.com/playdots/underpants/pull/1 in favor of this one.