### PR TITLE
Add functionality for domain groups

### DIFF
--- a/auth/google/google_test.go
+++ b/auth/google/google_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/playdots/underpants/config"
+	"github.com/playdots/underpants/user"
 )
 
 func TestAuthURLWithoutDomain(t *testing.T) {
@@ -100,5 +101,64 @@ func TestAuthURLWith(t *testing.T) {
 			param,
 			exp,
 			vals[param])
+	}
+}
+
+func TestValidateDomain(t *testing.T) {
+	ctx := &config.Context{
+		Info: &config.Info{
+			Oauth: config.OAuthInfo{
+				ClientID:     "client_id",
+				ClientSecret: "client_secret",
+				Domain:       "valid-domain.com",
+			},
+		},
+	}
+
+	user1 := &user.Info{
+		Name:    "name",
+		Email:   "user@valid-domain.com",
+	}
+
+	user2 := &user.Info{
+		Name:    "name",
+		Email:   "user@invalid-domain.com",
+	}
+
+	if _, err := ValidateDomain(ctx, user1); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ValidateDomain(ctx, user2); err == nil {
+		t.Fatalf("expected %s to fail validation", user2.Email)
+	}
+}
+
+func TestValidateDomainNotConfigured(t *testing.T) {
+	ctx := &config.Context{
+		Info: &config.Info{
+			Oauth: config.OAuthInfo{
+				ClientID:     "client_id",
+				ClientSecret: "client_secret",
+			},
+		},
+	}
+
+	user1 := &user.Info{
+		Name:    "name",
+		Email:   "user@valid-domain.com",
+	}
+
+	user2 := &user.Info{
+		Name:    "name",
+		Email:   "user@shady-domain.com",
+	}
+
+	if _, err := ValidateDomain(ctx, user1); err == nil {
+		t.Fatalf("expected %s to fail validation", user1.Email)
+	}
+
+	if _, err := ValidateDomain(ctx, user2); err == nil {
+		t.Fatalf("expected %s to fail validation", user2.Email)
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -43,6 +43,12 @@ type RouteInfo struct {
 	// A special group, `*`, may be specified which allows any authenticated
 	// user.
 	AllowedGroups []string `json:"allowed-groups"`
+
+	// A list of domain groups which may access this route.  If domain-groups are configured,
+	// users emails who are not a member of one of these domain-groups will be denied access.
+	// A special group, `*`, may be specified which allows any authenticated
+	// user.
+	AllowedDomainGroups []string `json:"allowed-domain-groups"`
 }
 
 // ToURL ...
@@ -88,6 +94,11 @@ type Info struct {
 	// a route is to deny all users not in a group on its allowed-groups list.
 	Groups map[string][]string
 
+	// A mapping of domain group names to lists of domains that are members
+	// of that group.  If this section is present, then the default behaviour for
+	// a route is to deny all email domains not present in that group.
+	DomainGroups map[string][]string `json:"domain-groups"`
+
 	// The mappings from hostname to backend server.
 	Routes []*RouteInfo
 }
@@ -102,6 +113,11 @@ func (i *Info) HasCerts() bool {
 // control lists.
 func (i *Info) HasGroups() bool {
 	return len(i.Groups) > 0
+}
+
+// HasDomainGroups is used to determine if the instance is configured for multiple domains.
+func (i *Info) HasDomainGroups() bool {
+	return len(i.DomainGroups) > 0
 }
 
 // Scheme is a convience method for getting the relevant scheme based on whether certificates were

--- a/config/context.go
+++ b/config/context.go
@@ -93,7 +93,8 @@ func (c *Context) DomainMemberOfAny(domain string, domainGroups []string) bool {
 	}
 
 	for _, domainGroup := range domainGroups {
-		// The semantics of * are as if there is an anonymous group that covers all users.
+		// The semantics of * are as if there is an anonymous group that covers all
+    // domains.
 		if domainGroup == "*" {
 			return true
 		}

--- a/config/context.go
+++ b/config/context.go
@@ -58,11 +58,11 @@ func BuildContext(cfg *Info, port int, key []byte) *Context {
 	}
 
 	return &Context{
-		Info:      		cfg,
-		Port:      		port,
-		Key:       		key,
-		groupIdx:  		groupIdx,
-		domainGroupIdx:		domainGroupIdx,
+		Info:           cfg,
+		Port:           port,
+		Key:            key,
+		groupIdx:       groupIdx,
+		domainGroupIdx: domainGroupIdx,
 	}
 }
 
@@ -94,7 +94,7 @@ func (c *Context) DomainMemberOfAny(domain string, domainGroups []string) bool {
 
 	for _, domainGroup := range domainGroups {
 		// The semantics of * are as if there is an anonymous group that covers all
-    // domains.
+		// domains.
 		if domainGroup == "*" {
 			return true
 		}

--- a/config/context_test.go
+++ b/config/context_test.go
@@ -42,3 +42,41 @@ func TestUserMemberOfAny(t *testing.T) {
 		}
 	}
 }
+
+type domainMemberOfAnyTest struct {
+	Domain         string
+	DomainGroups   []string
+	Expected       bool
+}
+
+func TestDomainMemberOfAny(t *testing.T) {
+	cfg := &Info{
+		DomainGroups: map[string][]string{
+			"a": {"a.com", "ab.com"},
+			"b": {"b.com"},
+		},
+	}
+
+	ctx := BuildContext(cfg, 80, []byte{})
+
+	tests := []domainMemberOfAnyTest{
+		{"c.com", []string{"a", "b"}, false},
+		{"c.com", []string{"*"}, true},
+
+		{"a.com", []string{}, false},
+		{"a.com", nil, false},
+		{"a.com", []string{"b"}, false},
+		{"a.com", []string{"a"}, true},
+		{"a.com", []string{"a", "b"}, true},
+		{"a.com", []string{"b", "*"}, true},
+	}
+
+	for _, test := range tests {
+		if ctx.DomainMemberOfAny(test.Domain, test.DomainGroups) != test.Expected {
+			t.Fatalf("%s member of any of %s should have been %t",
+				test.Domain,
+				strings.Join(test.DomainGroups, ","),
+				test.Expected)
+		}
+	}
+}

--- a/config/context_test.go
+++ b/config/context_test.go
@@ -44,9 +44,9 @@ func TestUserMemberOfAny(t *testing.T) {
 }
 
 type domainMemberOfAnyTest struct {
-	Domain         string
-	DomainGroups   []string
-	Expected       bool
+	Domain       string
+	DomainGroups []string
+	Expected     bool
 }
 
 func TestDomainMemberOfAny(t *testing.T) {
@@ -69,6 +69,31 @@ func TestDomainMemberOfAny(t *testing.T) {
 		{"a.com", []string{"a"}, true},
 		{"a.com", []string{"a", "b"}, true},
 		{"a.com", []string{"b", "*"}, true},
+	}
+
+	for _, test := range tests {
+		if ctx.DomainMemberOfAny(test.Domain, test.DomainGroups) != test.Expected {
+			t.Fatalf("%s member of any of %s should have been %t",
+				test.Domain,
+				strings.Join(test.DomainGroups, ","),
+				test.Expected)
+		}
+	}
+}
+
+func TestDomainMemberOfAnyWithNoAllowedDomainGroups(t *testing.T) {
+	cfg := &Info{
+		DomainGroups: map[string][]string{
+			"a": {"a.com"},
+			"b": {"b.com"},
+		},
+	}
+
+	ctx := BuildContext(cfg, 80, []byte{})
+
+	tests := []domainMemberOfAnyTest{
+		{"a.com", []string{}, false},
+		{"b.com", []string{}, false},
 	}
 
 	for _, test := range tests {

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -78,6 +78,19 @@ func (b *Backend) serveHTTPProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	email := strings.Split(u.Email, "@")
+	domain := email[len(email)-1]
+
+	if !b.Ctx.DomainMemberOfAny(domain, b.Route.AllowedDomainGroups) {
+		zap.L().Info("access denied (domain not in group)",
+			zap.String("from", b.Route.From),
+			zap.String("user", u.Email))
+		http.Error(w,
+			"Forbidden: your domain is not a member of the group authorized to view this site.",
+			http.StatusForbidden)
+		return
+	}
+
 	rebase, err := b.Route.ToURL().Parse(
 		strings.TrimLeft(r.URL.RequestURI(), "/"))
 	if err != nil {

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -81,13 +81,13 @@ func (b *Backend) serveHTTPProxy(w http.ResponseWriter, r *http.Request) {
 
 	// Validate properly formatted email address
 	if _, err := mail.ParseAddress(u.Email); err != nil {
-    http.Error(w,
-      "Forbidden: your email address is invalid.",
-      http.StatusForbidden)
-    return
-  }
+		http.Error(w,
+			"Forbidden: your email address is invalid.",
+			http.StatusForbidden)
+		return
+	}
 
-  email := strings.Split(u.Email, "@")
+	email := strings.Split(u.Email, "@")
 	domain := email[len(email)-1]
 
 	if !b.Ctx.DomainMemberOfAny(domain, b.Route.AllowedDomainGroups) {

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"io"
 	"net/http"
+	"net/mail"
 	"net/url"
 	"strings"
 
@@ -78,7 +79,15 @@ func (b *Backend) serveHTTPProxy(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	email := strings.Split(u.Email, "@")
+	// Validate properly formatted email address
+	if _, err := mail.ParseAddress(u.Email); err != nil {
+    http.Error(w,
+      "Forbidden: your email address is invalid.",
+      http.StatusForbidden)
+    return
+  }
+
+  email := strings.Split(u.Email, "@")
 	domain := email[len(email)-1]
 
 	if !b.Ctx.DomainMemberOfAny(domain, b.Route.AllowedDomainGroups) {


### PR DESCRIPTION
We want to be able authorize a user based on their email domain.
This functionality follows the same a pattern as the way `groups` are handled. _(see examples/underpants.groups.json)_

Related: https://github.com/playdots/underpants-eb/pull/13