### PR TITLE
update zap to 1.8

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -35,8 +35,8 @@
     "internal/exit",
     "zapcore"
   ]
-  revision = "35aad584952c3e7020db7b839f6b102de6271f89"
-  version = "v1.7.1"
+  revision = "eeedf312bc6c57391d84767a4cd413f02a917974"
+  version = "v1.8.0"
 
 [[projects]]
   branch = "master"

--- a/vendor/go.uber.org/zap/.travis.yml
+++ b/vendor/go.uber.org/zap/.travis.yml
@@ -1,13 +1,11 @@
 language: go
 sudo: false
 go:
-  - 1.7
-  - 1.8
-  - 1.9
+  - "1.9"
+  - "1.10"
 go_import_path: go.uber.org/zap
 env:
   global:
-    - GO15VENDOREXPERIMENT=1
     - TEST_TIMEOUT_SCALE=10
 cache:
   directories:

--- a/vendor/go.uber.org/zap/CHANGELOG.md
+++ b/vendor/go.uber.org/zap/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## v1.8.0 (13 Apr 2018)
+
+Enhancements:
+* [#508][]: Make log level configurable when redirecting the standard
+  library's logger.
+* [#518][]: Add a logger that writes to a `*testing.TB`.
+* [#577][]: Add a top-level alias for `zapcore.Field` to clean up GoDoc.
+
+Bugfixes:
+* [#574][]: Add a missing import comment to `go.uber.org/zap/buffer`.
+
+Thanks to @DiSiqueira and @djui for their contributions to this release.
+
 ## v1.7.1 (25 Sep 2017)
 
 Bugfixes:
@@ -266,5 +279,8 @@ upgrade to the upcoming stable release.
 [#487]: https://github.com/uber-go/zap/pull/487
 [#490]: https://github.com/uber-go/zap/pull/490
 [#491]: https://github.com/uber-go/zap/pull/491
-[#491]: https://github.com/uber-go/zap/pull/439
 [#504]: https://github.com/uber-go/zap/pull/504
+[#508]: https://github.com/uber-go/zap/pull/508
+[#518]: https://github.com/uber-go/zap/pull/518
+[#577]: https://github.com/uber-go/zap/pull/577
+[#574]: https://github.com/uber-go/zap/pull/574

--- a/vendor/go.uber.org/zap/FAQ.md
+++ b/vendor/go.uber.org/zap/FAQ.md
@@ -135,6 +135,20 @@ core := zapcore.NewCore(
 logger := zap.New(core)
 ```
 
+## Extensions
+
+We'd love to support every logging need within zap itself, but we're only
+familiar with a handful of log ingestion systems, flag-parsing packages, and
+the like. Rather than merging code that we can't effectively debug and
+support, we'd rather grow an ecosystem of zap extensions.
+
+We're aware of the following extensions, but haven't used them ourselves:
+
+| Package | Integration |
+| --- | --- |
+| `github.com/tchap/zapext` | Sentry, syslog |
+| `github.com/fgrosse/zaptest` | Ginkgo |
+
 [go-proverbs]: https://go-proverbs.github.io/
 [import-path]: https://golang.org/cmd/go/#hdr-Remote_import_paths
 [lumberjack]: https://godoc.org/gopkg.in/natefinch/lumberjack.v2

--- a/vendor/go.uber.org/zap/Makefile
+++ b/vendor/go.uber.org/zap/Makefile
@@ -3,13 +3,13 @@ export GO15VENDOREXPERIMENT=1
 BENCH_FLAGS ?= -cpuprofile=cpu.pprof -memprofile=mem.pprof -benchmem
 PKGS ?= $(shell glide novendor)
 # Many Go tools take file globs or directories as arguments instead of packages.
-PKG_FILES ?= *.go zapcore benchmarks buffer zapgrpc zaptest zaptest/observer internal/bufferpool internal/exit internal/color
+PKG_FILES ?= *.go zapcore benchmarks buffer zapgrpc zaptest zaptest/observer internal/bufferpool internal/exit internal/color internal/ztest
 
 # The linting tools evolve with each Go version, so run them only on the latest
 # stable release.
 GO_VERSION := $(shell go version | cut -d " " -f 3)
 GO_MINOR_VERSION := $(word 2,$(subst ., ,$(GO_VERSION)))
-LINTABLE_MINOR_VERSIONS := 8
+LINTABLE_MINOR_VERSIONS := 10
 ifneq ($(filter $(LINTABLE_MINOR_VERSIONS),$(GO_MINOR_VERSION)),)
 SHOULD_LINT := true
 endif

--- a/vendor/go.uber.org/zap/array.go
+++ b/vendor/go.uber.org/zap/array.go
@@ -29,113 +29,113 @@ import (
 // Array constructs a field with the given key and ArrayMarshaler. It provides
 // a flexible, but still type-safe and efficient, way to add array-like types
 // to the logging context. The struct's MarshalLogArray method is called lazily.
-func Array(key string, val zapcore.ArrayMarshaler) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.ArrayMarshalerType, Interface: val}
+func Array(key string, val zapcore.ArrayMarshaler) Field {
+	return Field{Key: key, Type: zapcore.ArrayMarshalerType, Interface: val}
 }
 
 // Bools constructs a field that carries a slice of bools.
-func Bools(key string, bs []bool) zapcore.Field {
+func Bools(key string, bs []bool) Field {
 	return Array(key, bools(bs))
 }
 
 // ByteStrings constructs a field that carries a slice of []byte, each of which
 // must be UTF-8 encoded text.
-func ByteStrings(key string, bss [][]byte) zapcore.Field {
+func ByteStrings(key string, bss [][]byte) Field {
 	return Array(key, byteStringsArray(bss))
 }
 
 // Complex128s constructs a field that carries a slice of complex numbers.
-func Complex128s(key string, nums []complex128) zapcore.Field {
+func Complex128s(key string, nums []complex128) Field {
 	return Array(key, complex128s(nums))
 }
 
 // Complex64s constructs a field that carries a slice of complex numbers.
-func Complex64s(key string, nums []complex64) zapcore.Field {
+func Complex64s(key string, nums []complex64) Field {
 	return Array(key, complex64s(nums))
 }
 
 // Durations constructs a field that carries a slice of time.Durations.
-func Durations(key string, ds []time.Duration) zapcore.Field {
+func Durations(key string, ds []time.Duration) Field {
 	return Array(key, durations(ds))
 }
 
 // Float64s constructs a field that carries a slice of floats.
-func Float64s(key string, nums []float64) zapcore.Field {
+func Float64s(key string, nums []float64) Field {
 	return Array(key, float64s(nums))
 }
 
 // Float32s constructs a field that carries a slice of floats.
-func Float32s(key string, nums []float32) zapcore.Field {
+func Float32s(key string, nums []float32) Field {
 	return Array(key, float32s(nums))
 }
 
 // Ints constructs a field that carries a slice of integers.
-func Ints(key string, nums []int) zapcore.Field {
+func Ints(key string, nums []int) Field {
 	return Array(key, ints(nums))
 }
 
 // Int64s constructs a field that carries a slice of integers.
-func Int64s(key string, nums []int64) zapcore.Field {
+func Int64s(key string, nums []int64) Field {
 	return Array(key, int64s(nums))
 }
 
 // Int32s constructs a field that carries a slice of integers.
-func Int32s(key string, nums []int32) zapcore.Field {
+func Int32s(key string, nums []int32) Field {
 	return Array(key, int32s(nums))
 }
 
 // Int16s constructs a field that carries a slice of integers.
-func Int16s(key string, nums []int16) zapcore.Field {
+func Int16s(key string, nums []int16) Field {
 	return Array(key, int16s(nums))
 }
 
 // Int8s constructs a field that carries a slice of integers.
-func Int8s(key string, nums []int8) zapcore.Field {
+func Int8s(key string, nums []int8) Field {
 	return Array(key, int8s(nums))
 }
 
 // Strings constructs a field that carries a slice of strings.
-func Strings(key string, ss []string) zapcore.Field {
+func Strings(key string, ss []string) Field {
 	return Array(key, stringArray(ss))
 }
 
 // Times constructs a field that carries a slice of time.Times.
-func Times(key string, ts []time.Time) zapcore.Field {
+func Times(key string, ts []time.Time) Field {
 	return Array(key, times(ts))
 }
 
 // Uints constructs a field that carries a slice of unsigned integers.
-func Uints(key string, nums []uint) zapcore.Field {
+func Uints(key string, nums []uint) Field {
 	return Array(key, uints(nums))
 }
 
 // Uint64s constructs a field that carries a slice of unsigned integers.
-func Uint64s(key string, nums []uint64) zapcore.Field {
+func Uint64s(key string, nums []uint64) Field {
 	return Array(key, uint64s(nums))
 }
 
 // Uint32s constructs a field that carries a slice of unsigned integers.
-func Uint32s(key string, nums []uint32) zapcore.Field {
+func Uint32s(key string, nums []uint32) Field {
 	return Array(key, uint32s(nums))
 }
 
 // Uint16s constructs a field that carries a slice of unsigned integers.
-func Uint16s(key string, nums []uint16) zapcore.Field {
+func Uint16s(key string, nums []uint16) Field {
 	return Array(key, uint16s(nums))
 }
 
 // Uint8s constructs a field that carries a slice of unsigned integers.
-func Uint8s(key string, nums []uint8) zapcore.Field {
+func Uint8s(key string, nums []uint8) Field {
 	return Array(key, uint8s(nums))
 }
 
 // Uintptrs constructs a field that carries a slice of pointer addresses.
-func Uintptrs(key string, us []uintptr) zapcore.Field {
+func Uintptrs(key string, us []uintptr) Field {
 	return Array(key, uintptrs(us))
 }
 
 // Errors constructs a field that carries a slice of errors.
-func Errors(key string, errs []error) zapcore.Field {
+func Errors(key string, errs []error) Field {
 	return Array(key, errArray(errs))
 }
 

--- a/vendor/go.uber.org/zap/array_test.go
+++ b/vendor/go.uber.org/zap/array_test.go
@@ -52,7 +52,7 @@ func BenchmarkBoolsReflect(b *testing.B) {
 func TestArrayWrappers(t *testing.T) {
 	tests := []struct {
 		desc     string
-		field    zapcore.Field
+		field    Field
 		expected []interface{}
 	}{
 		{"empty bools", Bools("", []bool{}), []interface{}(nil)},

--- a/vendor/go.uber.org/zap/benchmarks/zap_test.go
+++ b/vendor/go.uber.org/zap/benchmarks/zap_test.go
@@ -27,8 +27,8 @@ import (
 
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
+	"go.uber.org/zap/internal/ztest"
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 )
 
 var (
@@ -110,7 +110,7 @@ func newZapLogger(lvl zapcore.Level) *zap.Logger {
 	enc := zapcore.NewJSONEncoder(ec)
 	return zap.New(zapcore.NewCore(
 		enc,
-		&zaptest.Discarder{},
+		&ztest.Discarder{},
 		lvl,
 	))
 }
@@ -124,8 +124,8 @@ func newSampledLogger(lvl zapcore.Level) *zap.Logger {
 	))
 }
 
-func fakeFields() []zapcore.Field {
-	return []zapcore.Field{
+func fakeFields() []zap.Field {
+	return []zap.Field{
 		zap.Int("int", _tenInts[0]),
 		zap.Ints("ints", _tenInts),
 		zap.String("string", _tenStrings[0]),

--- a/vendor/go.uber.org/zap/buffer/buffer.go
+++ b/vendor/go.uber.org/zap/buffer/buffer.go
@@ -21,7 +21,7 @@
 // Package buffer provides a thin wrapper around a byte slice. Unlike the
 // standard library's bytes.Buffer, it supports a portion of the strconv
 // package's zero-allocation formatters.
-package buffer
+package buffer // import "go.uber.org/zap/buffer"
 
 import "strconv"
 

--- a/vendor/go.uber.org/zap/config.go
+++ b/vendor/go.uber.org/zap/config.go
@@ -210,7 +210,7 @@ func (cfg Config) buildOptions(errSink zapcore.WriteSyncer) []Option {
 	}
 
 	if len(cfg.InitialFields) > 0 {
-		fs := make([]zapcore.Field, 0, len(cfg.InitialFields))
+		fs := make([]Field, 0, len(cfg.InitialFields))
 		keys := make([]string, 0, len(cfg.InitialFields))
 		for k := range cfg.InitialFields {
 			keys = append(keys, k)

--- a/vendor/go.uber.org/zap/error.go
+++ b/vendor/go.uber.org/zap/error.go
@@ -31,7 +31,7 @@ var _errArrayElemPool = sync.Pool{New: func() interface{} {
 }}
 
 // Error is shorthand for the common idiom NamedError("error", err).
-func Error(err error) zapcore.Field {
+func Error(err error) Field {
 	return NamedError("error", err)
 }
 
@@ -42,11 +42,11 @@ func Error(err error) zapcore.Field {
 //
 // For the common case in which the key is simply "error", the Error function
 // is shorter and less repetitive.
-func NamedError(key string, err error) zapcore.Field {
+func NamedError(key string, err error) Field {
 	if err == nil {
 		return Skip()
 	}
-	return zapcore.Field{Key: key, Type: zapcore.ErrorType, Interface: err}
+	return Field{Key: key, Type: zapcore.ErrorType, Interface: err}
 }
 
 type errArray []error

--- a/vendor/go.uber.org/zap/error_test.go
+++ b/vendor/go.uber.org/zap/error_test.go
@@ -36,13 +36,13 @@ func TestErrorConstructors(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		field  zapcore.Field
-		expect zapcore.Field
+		field  Field
+		expect Field
 	}{
 		{"Error", Skip(), Error(nil)},
-		{"Error", zapcore.Field{Key: "error", Type: zapcore.ErrorType, Interface: fail}, Error(fail)},
+		{"Error", Field{Key: "error", Type: zapcore.ErrorType, Interface: fail}, Error(fail)},
 		{"NamedError", Skip(), NamedError("foo", nil)},
-		{"NamedError", zapcore.Field{Key: "foo", Type: zapcore.ErrorType, Interface: fail}, NamedError("foo", fail)},
+		{"NamedError", Field{Key: "foo", Type: zapcore.ErrorType, Interface: fail}, NamedError("foo", fail)},
 		{"Any:Error", Any("k", errors.New("v")), NamedError("k", errors.New("v"))},
 		{"Any:Errors", Any("k", []error{errors.New("v")}), Errors("k", []error{errors.New("v")})},
 	}
@@ -58,7 +58,7 @@ func TestErrorConstructors(t *testing.T) {
 func TestErrorArrayConstructor(t *testing.T) {
 	tests := []struct {
 		desc     string
-		field    zapcore.Field
+		field    Field
 		expected []interface{}
 	}{
 		{"empty errors", Errors("", []error{}), []interface{}(nil)},

--- a/vendor/go.uber.org/zap/field.go
+++ b/vendor/go.uber.org/zap/field.go
@@ -28,10 +28,14 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// Field is an alias for Field. Aliasing this type dramatically
+// improves the navigability of this package's API documentation.
+type Field = zapcore.Field
+
 // Skip constructs a no-op field, which is often useful when handling invalid
 // inputs in other Field constructors.
-func Skip() zapcore.Field {
-	return zapcore.Field{Type: zapcore.SkipType}
+func Skip() Field {
+	return Field{Type: zapcore.SkipType}
 }
 
 // Binary constructs a field that carries an opaque binary blob.
@@ -39,112 +43,112 @@ func Skip() zapcore.Field {
 // Binary data is serialized in an encoding-appropriate format. For example,
 // zap's JSON encoder base64-encodes binary blobs. To log UTF-8 encoded text,
 // use ByteString.
-func Binary(key string, val []byte) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.BinaryType, Interface: val}
+func Binary(key string, val []byte) Field {
+	return Field{Key: key, Type: zapcore.BinaryType, Interface: val}
 }
 
 // Bool constructs a field that carries a bool.
-func Bool(key string, val bool) zapcore.Field {
+func Bool(key string, val bool) Field {
 	var ival int64
 	if val {
 		ival = 1
 	}
-	return zapcore.Field{Key: key, Type: zapcore.BoolType, Integer: ival}
+	return Field{Key: key, Type: zapcore.BoolType, Integer: ival}
 }
 
 // ByteString constructs a field that carries UTF-8 encoded text as a []byte.
 // To log opaque binary blobs (which aren't necessarily valid UTF-8), use
 // Binary.
-func ByteString(key string, val []byte) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.ByteStringType, Interface: val}
+func ByteString(key string, val []byte) Field {
+	return Field{Key: key, Type: zapcore.ByteStringType, Interface: val}
 }
 
 // Complex128 constructs a field that carries a complex number. Unlike most
 // numeric fields, this costs an allocation (to convert the complex128 to
 // interface{}).
-func Complex128(key string, val complex128) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.Complex128Type, Interface: val}
+func Complex128(key string, val complex128) Field {
+	return Field{Key: key, Type: zapcore.Complex128Type, Interface: val}
 }
 
 // Complex64 constructs a field that carries a complex number. Unlike most
 // numeric fields, this costs an allocation (to convert the complex64 to
 // interface{}).
-func Complex64(key string, val complex64) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.Complex64Type, Interface: val}
+func Complex64(key string, val complex64) Field {
+	return Field{Key: key, Type: zapcore.Complex64Type, Interface: val}
 }
 
 // Float64 constructs a field that carries a float64. The way the
 // floating-point value is represented is encoder-dependent, so marshaling is
 // necessarily lazy.
-func Float64(key string, val float64) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.Float64Type, Integer: int64(math.Float64bits(val))}
+func Float64(key string, val float64) Field {
+	return Field{Key: key, Type: zapcore.Float64Type, Integer: int64(math.Float64bits(val))}
 }
 
 // Float32 constructs a field that carries a float32. The way the
 // floating-point value is represented is encoder-dependent, so marshaling is
 // necessarily lazy.
-func Float32(key string, val float32) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.Float32Type, Integer: int64(math.Float32bits(val))}
+func Float32(key string, val float32) Field {
+	return Field{Key: key, Type: zapcore.Float32Type, Integer: int64(math.Float32bits(val))}
 }
 
 // Int constructs a field with the given key and value.
-func Int(key string, val int) zapcore.Field {
+func Int(key string, val int) Field {
 	return Int64(key, int64(val))
 }
 
 // Int64 constructs a field with the given key and value.
-func Int64(key string, val int64) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.Int64Type, Integer: val}
+func Int64(key string, val int64) Field {
+	return Field{Key: key, Type: zapcore.Int64Type, Integer: val}
 }
 
 // Int32 constructs a field with the given key and value.
-func Int32(key string, val int32) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.Int32Type, Integer: int64(val)}
+func Int32(key string, val int32) Field {
+	return Field{Key: key, Type: zapcore.Int32Type, Integer: int64(val)}
 }
 
 // Int16 constructs a field with the given key and value.
-func Int16(key string, val int16) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.Int16Type, Integer: int64(val)}
+func Int16(key string, val int16) Field {
+	return Field{Key: key, Type: zapcore.Int16Type, Integer: int64(val)}
 }
 
 // Int8 constructs a field with the given key and value.
-func Int8(key string, val int8) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.Int8Type, Integer: int64(val)}
+func Int8(key string, val int8) Field {
+	return Field{Key: key, Type: zapcore.Int8Type, Integer: int64(val)}
 }
 
 // String constructs a field with the given key and value.
-func String(key string, val string) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.StringType, String: val}
+func String(key string, val string) Field {
+	return Field{Key: key, Type: zapcore.StringType, String: val}
 }
 
 // Uint constructs a field with the given key and value.
-func Uint(key string, val uint) zapcore.Field {
+func Uint(key string, val uint) Field {
 	return Uint64(key, uint64(val))
 }
 
 // Uint64 constructs a field with the given key and value.
-func Uint64(key string, val uint64) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.Uint64Type, Integer: int64(val)}
+func Uint64(key string, val uint64) Field {
+	return Field{Key: key, Type: zapcore.Uint64Type, Integer: int64(val)}
 }
 
 // Uint32 constructs a field with the given key and value.
-func Uint32(key string, val uint32) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.Uint32Type, Integer: int64(val)}
+func Uint32(key string, val uint32) Field {
+	return Field{Key: key, Type: zapcore.Uint32Type, Integer: int64(val)}
 }
 
 // Uint16 constructs a field with the given key and value.
-func Uint16(key string, val uint16) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.Uint16Type, Integer: int64(val)}
+func Uint16(key string, val uint16) Field {
+	return Field{Key: key, Type: zapcore.Uint16Type, Integer: int64(val)}
 }
 
 // Uint8 constructs a field with the given key and value.
-func Uint8(key string, val uint8) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.Uint8Type, Integer: int64(val)}
+func Uint8(key string, val uint8) Field {
+	return Field{Key: key, Type: zapcore.Uint8Type, Integer: int64(val)}
 }
 
 // Uintptr constructs a field with the given key and value.
-func Uintptr(key string, val uintptr) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.UintptrType, Integer: int64(val)}
+func Uintptr(key string, val uintptr) Field {
+	return Field{Key: key, Type: zapcore.UintptrType, Integer: int64(val)}
 }
 
 // Reflect constructs a field with the given key and an arbitrary object. It uses
@@ -154,8 +158,8 @@ func Uintptr(key string, val uintptr) zapcore.Field {
 //
 // If encoding fails (e.g., trying to serialize a map[int]string to JSON), Reflect
 // includes the error message in the final log output.
-func Reflect(key string, val interface{}) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.ReflectType, Interface: val}
+func Reflect(key string, val interface{}) Field {
+	return Field{Key: key, Type: zapcore.ReflectType, Interface: val}
 }
 
 // Namespace creates a named, isolated scope within the logger's context. All
@@ -163,27 +167,27 @@ func Reflect(key string, val interface{}) zapcore.Field {
 //
 // This helps prevent key collisions when injecting loggers into sub-components
 // or third-party libraries.
-func Namespace(key string) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.NamespaceType}
+func Namespace(key string) Field {
+	return Field{Key: key, Type: zapcore.NamespaceType}
 }
 
 // Stringer constructs a field with the given key and the output of the value's
 // String method. The Stringer's String method is called lazily.
-func Stringer(key string, val fmt.Stringer) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.StringerType, Interface: val}
+func Stringer(key string, val fmt.Stringer) Field {
+	return Field{Key: key, Type: zapcore.StringerType, Interface: val}
 }
 
-// Time constructs a zapcore.Field with the given key and value. The encoder
+// Time constructs a Field with the given key and value. The encoder
 // controls how the time is serialized.
-func Time(key string, val time.Time) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.TimeType, Integer: val.UnixNano(), Interface: val.Location()}
+func Time(key string, val time.Time) Field {
+	return Field{Key: key, Type: zapcore.TimeType, Integer: val.UnixNano(), Interface: val.Location()}
 }
 
 // Stack constructs a field that stores a stacktrace of the current goroutine
 // under provided key. Keep in mind that taking a stacktrace is eager and
 // expensive (relatively speaking); this function both makes an allocation and
 // takes about two microseconds.
-func Stack(key string) zapcore.Field {
+func Stack(key string) Field {
 	// Returning the stacktrace as a string costs an allocation, but saves us
 	// from expanding the zapcore.Field union struct to include a byte slice. Since
 	// taking a stacktrace is already so expensive (~10us), the extra allocation
@@ -193,16 +197,16 @@ func Stack(key string) zapcore.Field {
 
 // Duration constructs a field with the given key and value. The encoder
 // controls how the duration is serialized.
-func Duration(key string, val time.Duration) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.DurationType, Integer: int64(val)}
+func Duration(key string, val time.Duration) Field {
+	return Field{Key: key, Type: zapcore.DurationType, Integer: int64(val)}
 }
 
 // Object constructs a field with the given key and ObjectMarshaler. It
 // provides a flexible, but still type-safe and efficient, way to add map- or
 // struct-like user-defined types to the logging context. The struct's
 // MarshalLogObject method is called lazily.
-func Object(key string, val zapcore.ObjectMarshaler) zapcore.Field {
-	return zapcore.Field{Key: key, Type: zapcore.ObjectMarshalerType, Interface: val}
+func Object(key string, val zapcore.ObjectMarshaler) Field {
+	return Field{Key: key, Type: zapcore.ObjectMarshalerType, Interface: val}
 }
 
 // Any takes a key and an arbitrary value and chooses the best way to represent
@@ -210,9 +214,9 @@ func Object(key string, val zapcore.ObjectMarshaler) zapcore.Field {
 // necessary.
 //
 // Since byte/uint8 and rune/int32 are aliases, Any can't differentiate between
-// them. To minimize suprise, []byte values are treated as binary blobs, byte
+// them. To minimize surprises, []byte values are treated as binary blobs, byte
 // values are treated as uint8, and runes are always treated as integers.
-func Any(key string, value interface{}) zapcore.Field {
+func Any(key string, value interface{}) Field {
 	switch val := value.(type) {
 	case zapcore.ObjectMarshaler:
 		return Object(key, val)

--- a/vendor/go.uber.org/zap/field_test.go
+++ b/vendor/go.uber.org/zap/field_test.go
@@ -37,7 +37,7 @@ func (n username) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	return nil
 }
 
-func assertCanBeReused(t testing.TB, field zapcore.Field) {
+func assertCanBeReused(t testing.TB, field Field) {
 	var wg sync.WaitGroup
 
 	for i := 0; i < 100; i++ {
@@ -65,34 +65,34 @@ func TestFieldConstructors(t *testing.T) {
 
 	tests := []struct {
 		name   string
-		field  zapcore.Field
-		expect zapcore.Field
+		field  Field
+		expect Field
 	}{
-		{"Skip", zapcore.Field{Type: zapcore.SkipType}, Skip()},
-		{"Binary", zapcore.Field{Key: "k", Type: zapcore.BinaryType, Interface: []byte("ab12")}, Binary("k", []byte("ab12"))},
-		{"Bool", zapcore.Field{Key: "k", Type: zapcore.BoolType, Integer: 1}, Bool("k", true)},
-		{"Bool", zapcore.Field{Key: "k", Type: zapcore.BoolType, Integer: 1}, Bool("k", true)},
-		{"ByteString", zapcore.Field{Key: "k", Type: zapcore.ByteStringType, Interface: []byte("ab12")}, ByteString("k", []byte("ab12"))},
-		{"Complex128", zapcore.Field{Key: "k", Type: zapcore.Complex128Type, Interface: 1 + 2i}, Complex128("k", 1+2i)},
-		{"Complex64", zapcore.Field{Key: "k", Type: zapcore.Complex64Type, Interface: complex64(1 + 2i)}, Complex64("k", 1+2i)},
-		{"Duration", zapcore.Field{Key: "k", Type: zapcore.DurationType, Integer: 1}, Duration("k", 1)},
-		{"Int", zapcore.Field{Key: "k", Type: zapcore.Int64Type, Integer: 1}, Int("k", 1)},
-		{"Int64", zapcore.Field{Key: "k", Type: zapcore.Int64Type, Integer: 1}, Int64("k", 1)},
-		{"Int32", zapcore.Field{Key: "k", Type: zapcore.Int32Type, Integer: 1}, Int32("k", 1)},
-		{"Int16", zapcore.Field{Key: "k", Type: zapcore.Int16Type, Integer: 1}, Int16("k", 1)},
-		{"Int8", zapcore.Field{Key: "k", Type: zapcore.Int8Type, Integer: 1}, Int8("k", 1)},
-		{"String", zapcore.Field{Key: "k", Type: zapcore.StringType, String: "foo"}, String("k", "foo")},
-		{"Time", zapcore.Field{Key: "k", Type: zapcore.TimeType, Integer: 0, Interface: time.UTC}, Time("k", time.Unix(0, 0).In(time.UTC))},
-		{"Time", zapcore.Field{Key: "k", Type: zapcore.TimeType, Integer: 1000, Interface: time.UTC}, Time("k", time.Unix(0, 1000).In(time.UTC))},
-		{"Uint", zapcore.Field{Key: "k", Type: zapcore.Uint64Type, Integer: 1}, Uint("k", 1)},
-		{"Uint64", zapcore.Field{Key: "k", Type: zapcore.Uint64Type, Integer: 1}, Uint64("k", 1)},
-		{"Uint32", zapcore.Field{Key: "k", Type: zapcore.Uint32Type, Integer: 1}, Uint32("k", 1)},
-		{"Uint16", zapcore.Field{Key: "k", Type: zapcore.Uint16Type, Integer: 1}, Uint16("k", 1)},
-		{"Uint8", zapcore.Field{Key: "k", Type: zapcore.Uint8Type, Integer: 1}, Uint8("k", 1)},
-		{"Uintptr", zapcore.Field{Key: "k", Type: zapcore.UintptrType, Integer: 10}, Uintptr("k", 0xa)},
-		{"Reflect", zapcore.Field{Key: "k", Type: zapcore.ReflectType, Interface: ints}, Reflect("k", ints)},
-		{"Stringer", zapcore.Field{Key: "k", Type: zapcore.StringerType, Interface: addr}, Stringer("k", addr)},
-		{"Object", zapcore.Field{Key: "k", Type: zapcore.ObjectMarshalerType, Interface: name}, Object("k", name)},
+		{"Skip", Field{Type: zapcore.SkipType}, Skip()},
+		{"Binary", Field{Key: "k", Type: zapcore.BinaryType, Interface: []byte("ab12")}, Binary("k", []byte("ab12"))},
+		{"Bool", Field{Key: "k", Type: zapcore.BoolType, Integer: 1}, Bool("k", true)},
+		{"Bool", Field{Key: "k", Type: zapcore.BoolType, Integer: 1}, Bool("k", true)},
+		{"ByteString", Field{Key: "k", Type: zapcore.ByteStringType, Interface: []byte("ab12")}, ByteString("k", []byte("ab12"))},
+		{"Complex128", Field{Key: "k", Type: zapcore.Complex128Type, Interface: 1 + 2i}, Complex128("k", 1+2i)},
+		{"Complex64", Field{Key: "k", Type: zapcore.Complex64Type, Interface: complex64(1 + 2i)}, Complex64("k", 1+2i)},
+		{"Duration", Field{Key: "k", Type: zapcore.DurationType, Integer: 1}, Duration("k", 1)},
+		{"Int", Field{Key: "k", Type: zapcore.Int64Type, Integer: 1}, Int("k", 1)},
+		{"Int64", Field{Key: "k", Type: zapcore.Int64Type, Integer: 1}, Int64("k", 1)},
+		{"Int32", Field{Key: "k", Type: zapcore.Int32Type, Integer: 1}, Int32("k", 1)},
+		{"Int16", Field{Key: "k", Type: zapcore.Int16Type, Integer: 1}, Int16("k", 1)},
+		{"Int8", Field{Key: "k", Type: zapcore.Int8Type, Integer: 1}, Int8("k", 1)},
+		{"String", Field{Key: "k", Type: zapcore.StringType, String: "foo"}, String("k", "foo")},
+		{"Time", Field{Key: "k", Type: zapcore.TimeType, Integer: 0, Interface: time.UTC}, Time("k", time.Unix(0, 0).In(time.UTC))},
+		{"Time", Field{Key: "k", Type: zapcore.TimeType, Integer: 1000, Interface: time.UTC}, Time("k", time.Unix(0, 1000).In(time.UTC))},
+		{"Uint", Field{Key: "k", Type: zapcore.Uint64Type, Integer: 1}, Uint("k", 1)},
+		{"Uint64", Field{Key: "k", Type: zapcore.Uint64Type, Integer: 1}, Uint64("k", 1)},
+		{"Uint32", Field{Key: "k", Type: zapcore.Uint32Type, Integer: 1}, Uint32("k", 1)},
+		{"Uint16", Field{Key: "k", Type: zapcore.Uint16Type, Integer: 1}, Uint16("k", 1)},
+		{"Uint8", Field{Key: "k", Type: zapcore.Uint8Type, Integer: 1}, Uint8("k", 1)},
+		{"Uintptr", Field{Key: "k", Type: zapcore.UintptrType, Integer: 10}, Uintptr("k", 0xa)},
+		{"Reflect", Field{Key: "k", Type: zapcore.ReflectType, Interface: ints}, Reflect("k", ints)},
+		{"Stringer", Field{Key: "k", Type: zapcore.StringerType, Interface: addr}, Stringer("k", addr)},
+		{"Object", Field{Key: "k", Type: zapcore.ObjectMarshalerType, Interface: name}, Object("k", name)},
 		{"Any:ObjectMarshaler", Any("k", name), Object("k", name)},
 		{"Any:ArrayMarshaler", Any("k", bools([]bool{true})), Array("k", bools([]bool{true}))},
 		{"Any:Stringer", Any("k", addr), Stringer("k", addr)},
@@ -139,7 +139,7 @@ func TestFieldConstructors(t *testing.T) {
 		{"Any:Duration", Any("k", time.Second), Duration("k", time.Second)},
 		{"Any:Durations", Any("k", []time.Duration{time.Second}), Durations("k", []time.Duration{time.Second})},
 		{"Any:Fallback", Any("k", struct{}{}), Reflect("k", struct{}{})},
-		{"Namespace", Namespace("k"), zapcore.Field{Key: "k", Type: zapcore.NamespaceType}},
+		{"Namespace", Namespace("k"), Field{Key: "k", Type: zapcore.NamespaceType}},
 	}
 
 	for _, tt := range tests {

--- a/vendor/go.uber.org/zap/global.go
+++ b/vendor/go.uber.org/zap/global.go
@@ -31,8 +31,10 @@ import (
 )
 
 const (
-	_stdLogDefaultDepth = 2
-	_loggerWriterDepth  = 2
+	_stdLogDefaultDepth      = 2
+	_loggerWriterDepth       = 2
+	_programmerErrorTemplate = "You've found a bug in zap! Please file a bug at " +
+		"https://github.com/uber-go/zap/issues/new and reference this error: %v"
 )
 
 var (
@@ -83,24 +85,9 @@ func NewStdLog(l *Logger) *log.Logger {
 // required level.
 func NewStdLogAt(l *Logger, level zapcore.Level) (*log.Logger, error) {
 	logger := l.WithOptions(AddCallerSkip(_stdLogDefaultDepth + _loggerWriterDepth))
-	var logFunc func(string, ...zapcore.Field)
-	switch level {
-	case DebugLevel:
-		logFunc = logger.Debug
-	case InfoLevel:
-		logFunc = logger.Info
-	case WarnLevel:
-		logFunc = logger.Warn
-	case ErrorLevel:
-		logFunc = logger.Error
-	case DPanicLevel:
-		logFunc = logger.DPanic
-	case PanicLevel:
-		logFunc = logger.Panic
-	case FatalLevel:
-		logFunc = logger.Fatal
-	default:
-		return nil, fmt.Errorf("unrecognized level: %q", level)
+	logFunc, err := levelToFunc(logger, level)
+	if err != nil {
+		return nil, err
 	}
 	return log.New(&loggerWriter{logFunc}, "" /* prefix */, 0 /* flags */), nil
 }
@@ -111,25 +98,68 @@ func NewStdLogAt(l *Logger, level zapcore.Level) (*log.Logger, error) {
 // library's annotations and prefixing.
 //
 // It returns a function to restore the original prefix and flags and reset the
-// standard library's output to os.Stdout.
+// standard library's output to os.Stderr.
 func RedirectStdLog(l *Logger) func() {
+	f, err := redirectStdLogAt(l, InfoLevel)
+	if err != nil {
+		// Can't get here, since passing InfoLevel to redirectStdLogAt always
+		// works.
+		panic(fmt.Sprintf(_programmerErrorTemplate, err))
+	}
+	return f
+}
+
+// RedirectStdLogAt redirects output from the standard library's package-global
+// logger to the supplied logger at the specified level. Since zap already
+// handles caller annotations, timestamps, etc., it automatically disables the
+// standard library's annotations and prefixing.
+//
+// It returns a function to restore the original prefix and flags and reset the
+// standard library's output to os.Stderr.
+func RedirectStdLogAt(l *Logger, level zapcore.Level) (func(), error) {
+	return redirectStdLogAt(l, level)
+}
+
+func redirectStdLogAt(l *Logger, level zapcore.Level) (func(), error) {
 	flags := log.Flags()
 	prefix := log.Prefix()
 	log.SetFlags(0)
 	log.SetPrefix("")
-	logFunc := l.WithOptions(
-		AddCallerSkip(_stdLogDefaultDepth + _loggerWriterDepth),
-	).Info
+	logger := l.WithOptions(AddCallerSkip(_stdLogDefaultDepth + _loggerWriterDepth))
+	logFunc, err := levelToFunc(logger, level)
+	if err != nil {
+		return nil, err
+	}
 	log.SetOutput(&loggerWriter{logFunc})
 	return func() {
 		log.SetFlags(flags)
 		log.SetPrefix(prefix)
 		log.SetOutput(os.Stderr)
+	}, nil
+}
+
+func levelToFunc(logger *Logger, lvl zapcore.Level) (func(string, ...Field), error) {
+	switch lvl {
+	case DebugLevel:
+		return logger.Debug, nil
+	case InfoLevel:
+		return logger.Info, nil
+	case WarnLevel:
+		return logger.Warn, nil
+	case ErrorLevel:
+		return logger.Error, nil
+	case DPanicLevel:
+		return logger.DPanic, nil
+	case PanicLevel:
+		return logger.Panic, nil
+	case FatalLevel:
+		return logger.Fatal, nil
 	}
+	return nil, fmt.Errorf("unrecognized level: %q", lvl)
 }
 
 type loggerWriter struct {
-	logFunc func(msg string, fields ...zapcore.Field)
+	logFunc func(msg string, fields ...Field)
 }
 
 func (l *loggerWriter) Write(p []byte) (int, error) {

--- a/vendor/go.uber.org/zap/global_test.go
+++ b/vendor/go.uber.org/zap/global_test.go
@@ -27,9 +27,9 @@ import (
 	"time"
 
 	"go.uber.org/zap/internal/exit"
+	"go.uber.org/zap/internal/ztest"
 
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
@@ -52,7 +52,7 @@ func TestReplaceGlobals(t *testing.T) {
 		S().Info("captured")
 		expected := observer.LoggedEntry{
 			Entry:   zapcore.Entry{Message: "captured"},
-			Context: []zapcore.Field{},
+			Context: []Field{},
 		}
 		assert.Equal(
 			t,
@@ -89,7 +89,7 @@ func TestGlobalsConcurrentUse(t *testing.T) {
 		}()
 	}
 
-	zaptest.Sleep(100 * time.Millisecond)
+	ztest.Sleep(100 * time.Millisecond)
 	stop.Toggle()
 	wg.Wait()
 }
@@ -157,7 +157,7 @@ func TestRedirectStdLog(t *testing.T) {
 
 		assert.Equal(t, []observer.LoggedEntry{{
 			Entry:   zapcore.Entry{Message: "redirected"},
-			Context: []zapcore.Field{},
+			Context: []Field{},
 		}}, logs.AllUntimed(), "Unexpected global log output.")
 	})
 
@@ -175,10 +175,101 @@ func TestRedirectStdLogCaller(t *testing.T) {
 	})
 }
 
+func TestRedirectStdLogAt(t *testing.T) {
+	initialFlags := log.Flags()
+	initialPrefix := log.Prefix()
+
+	// include DPanicLevel here, but do not include Development in options
+	levels := []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel}
+	for _, level := range levels {
+		withLogger(t, DebugLevel, nil, func(l *Logger, logs *observer.ObservedLogs) {
+			restore, err := RedirectStdLogAt(l, level)
+			require.NoError(t, err, "Unexpected error.")
+			defer restore()
+			log.Print("redirected")
+
+			assert.Equal(t, []observer.LoggedEntry{{
+				Entry:   zapcore.Entry{Level: level, Message: "redirected"},
+				Context: []Field{},
+			}}, logs.AllUntimed(), "Unexpected global log output.")
+		})
+	}
+
+	assert.Equal(t, initialFlags, log.Flags(), "Expected to reset initial flags.")
+	assert.Equal(t, initialPrefix, log.Prefix(), "Expected to reset initial prefix.")
+}
+
+func TestRedirectStdLogAtCaller(t *testing.T) {
+	// include DPanicLevel here, but do not include Development in options
+	levels := []zapcore.Level{DebugLevel, InfoLevel, WarnLevel, ErrorLevel, DPanicLevel}
+	for _, level := range levels {
+		withLogger(t, DebugLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
+			restore, err := RedirectStdLogAt(l, level)
+			require.NoError(t, err, "Unexpected error.")
+			defer restore()
+			log.Print("redirected")
+			entries := logs.All()
+			require.Len(t, entries, 1, "Unexpected number of logs.")
+			assert.Contains(t, entries[0].Entry.Caller.File, "global_test.go", "Unexpected caller annotation.")
+		})
+	}
+}
+
+func TestRedirectStdLogAtPanics(t *testing.T) {
+	initialFlags := log.Flags()
+	initialPrefix := log.Prefix()
+
+	// include DPanicLevel here and enable Development in options
+	levels := []zapcore.Level{DPanicLevel, PanicLevel}
+	for _, level := range levels {
+		withLogger(t, DebugLevel, []Option{AddCaller(), Development()}, func(l *Logger, logs *observer.ObservedLogs) {
+			restore, err := RedirectStdLogAt(l, level)
+			require.NoError(t, err, "Unexpected error.")
+			defer restore()
+			assert.Panics(t, func() { log.Print("redirected") }, "Expected log to panic.")
+			checkStdLogMessage(t, "redirected", logs)
+		})
+	}
+
+	assert.Equal(t, initialFlags, log.Flags(), "Expected to reset initial flags.")
+	assert.Equal(t, initialPrefix, log.Prefix(), "Expected to reset initial prefix.")
+}
+
+func TestRedirectStdLogAtFatal(t *testing.T) {
+	initialFlags := log.Flags()
+	initialPrefix := log.Prefix()
+
+	withLogger(t, DebugLevel, []Option{AddCaller()}, func(l *Logger, logs *observer.ObservedLogs) {
+		stub := exit.WithStub(func() {
+			restore, err := RedirectStdLogAt(l, FatalLevel)
+			require.NoError(t, err, "Unexpected error.")
+			defer restore()
+			log.Print("redirected")
+			checkStdLogMessage(t, "redirected", logs)
+		})
+		assert.True(t, true, stub.Exited, "Expected Fatal logger call to terminate process.")
+		stub.Unstub()
+	})
+
+	assert.Equal(t, initialFlags, log.Flags(), "Expected to reset initial flags.")
+	assert.Equal(t, initialPrefix, log.Prefix(), "Expected to reset initial prefix.")
+}
+
+func TestRedirectStdLogAtInvalid(t *testing.T) {
+	restore, err := RedirectStdLogAt(NewNop(), zapcore.Level(99))
+	defer func() {
+		if restore != nil {
+			restore()
+		}
+	}()
+	require.Error(t, err, "Expected to get error.")
+	assert.Contains(t, err.Error(), "99", "Expected level code in error message")
+}
+
 func checkStdLogMessage(t *testing.T, msg string, logs *observer.ObservedLogs) {
 	require.Equal(t, 1, logs.Len(), "Expected exactly one entry to be logged")
 	entry := logs.AllUntimed()[0]
-	assert.Equal(t, []zapcore.Field{}, entry.Context, "Unexpected entry context.")
+	assert.Equal(t, []Field{}, entry.Context, "Unexpected entry context.")
 	assert.Equal(t, "redirected", entry.Entry.Message, "Unexpected entry message.")
 	assert.Regexp(
 		t,

--- a/vendor/go.uber.org/zap/internal/readme/readme.go
+++ b/vendor/go.uber.org/zap/internal/readme/readme.go
@@ -68,10 +68,7 @@ func do() error {
 	if err != nil {
 		return err
 	}
-	if err := t.Execute(os.Stdout, tmplData); err != nil {
-		return err
-	}
-	return nil
+	return t.Execute(os.Stdout, tmplData)
 }
 
 func getTmplData() (*tmplData, error) {

--- a/vendor/go.uber.org/zap/internal/ztest/doc.go
+++ b/vendor/go.uber.org/zap/internal/ztest/doc.go
@@ -18,39 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package zapcore
-
-import (
-	"testing"
-
-	"go.uber.org/zap/internal/ztest"
-)
-
-func BenchmarkMultiWriteSyncer(b *testing.B) {
-	b.Run("2", func(b *testing.B) {
-		w := NewMultiWriteSyncer(
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-		)
-		b.ResetTimer()
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				w.Write([]byte("foobarbazbabble"))
-			}
-		})
-	})
-	b.Run("4", func(b *testing.B) {
-		w := NewMultiWriteSyncer(
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-		)
-		b.ResetTimer()
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				w.Write([]byte("foobarbazbabble"))
-			}
-		})
-	})
-}
+// Package ztest provides low-level helpers for testing log output. These
+// utilities are helpful in zap's own unit tests, but any assertions using
+// them are strongly coupled to a single encoding.
+package ztest // import "go.uber.org/zap/internal/ztest"

--- a/vendor/go.uber.org/zap/internal/ztest/writer.go
+++ b/vendor/go.uber.org/zap/internal/ztest/writer.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package ztest
+
+import (
+	"bytes"
+	"errors"
+	"io/ioutil"
+	"strings"
+)
+
+// A Syncer is a spy for the Sync portion of zapcore.WriteSyncer.
+type Syncer struct {
+	err    error
+	called bool
+}
+
+// SetError sets the error that the Sync method will return.
+func (s *Syncer) SetError(err error) {
+	s.err = err
+}
+
+// Sync records that it was called, then returns the user-supplied error (if
+// any).
+func (s *Syncer) Sync() error {
+	s.called = true
+	return s.err
+}
+
+// Called reports whether the Sync method was called.
+func (s *Syncer) Called() bool {
+	return s.called
+}
+
+// A Discarder sends all writes to ioutil.Discard.
+type Discarder struct{ Syncer }
+
+// Write implements io.Writer.
+func (d *Discarder) Write(b []byte) (int, error) {
+	return ioutil.Discard.Write(b)
+}
+
+// FailWriter is a WriteSyncer that always returns an error on writes.
+type FailWriter struct{ Syncer }
+
+// Write implements io.Writer.
+func (w FailWriter) Write(b []byte) (int, error) {
+	return len(b), errors.New("failed")
+}
+
+// ShortWriter is a WriteSyncer whose write method never fails, but
+// nevertheless fails to the last byte of the input.
+type ShortWriter struct{ Syncer }
+
+// Write implements io.Writer.
+func (w ShortWriter) Write(b []byte) (int, error) {
+	return len(b) - 1, nil
+}
+
+// Buffer is an implementation of zapcore.WriteSyncer that sends all writes to
+// a bytes.Buffer. It has convenience methods to split the accumulated buffer
+// on newlines.
+type Buffer struct {
+	bytes.Buffer
+	Syncer
+}
+
+// Lines returns the current buffer contents, split on newlines.
+func (b *Buffer) Lines() []string {
+	output := strings.Split(b.String(), "\n")
+	return output[:len(output)-1]
+}
+
+// Stripped returns the current buffer contents with the last trailing newline
+// stripped.
+func (b *Buffer) Stripped() string {
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/vendor/go.uber.org/zap/level.go
+++ b/vendor/go.uber.org/zap/level.go
@@ -78,7 +78,7 @@ func NewAtomicLevel() AtomicLevel {
 	}
 }
 
-// NewAtomicLevelAt is a convienence function that creates an AtomicLevel
+// NewAtomicLevelAt is a convenience function that creates an AtomicLevel
 // and then calls SetLevel with the given level.
 func NewAtomicLevelAt(l zapcore.Level) AtomicLevel {
 	a := NewAtomicLevel()

--- a/vendor/go.uber.org/zap/logger.go
+++ b/vendor/go.uber.org/zap/logger.go
@@ -156,7 +156,7 @@ func (log *Logger) WithOptions(opts ...Option) *Logger {
 
 // With creates a child logger and adds structured context to it. Fields added
 // to the child don't affect the parent, and vice versa.
-func (log *Logger) With(fields ...zapcore.Field) *Logger {
+func (log *Logger) With(fields ...Field) *Logger {
 	if len(fields) == 0 {
 		return log
 	}
@@ -174,7 +174,7 @@ func (log *Logger) Check(lvl zapcore.Level, msg string) *zapcore.CheckedEntry {
 
 // Debug logs a message at DebugLevel. The message includes any fields passed
 // at the log site, as well as any fields accumulated on the logger.
-func (log *Logger) Debug(msg string, fields ...zapcore.Field) {
+func (log *Logger) Debug(msg string, fields ...Field) {
 	if ce := log.check(DebugLevel, msg); ce != nil {
 		ce.Write(fields...)
 	}
@@ -182,7 +182,7 @@ func (log *Logger) Debug(msg string, fields ...zapcore.Field) {
 
 // Info logs a message at InfoLevel. The message includes any fields passed
 // at the log site, as well as any fields accumulated on the logger.
-func (log *Logger) Info(msg string, fields ...zapcore.Field) {
+func (log *Logger) Info(msg string, fields ...Field) {
 	if ce := log.check(InfoLevel, msg); ce != nil {
 		ce.Write(fields...)
 	}
@@ -190,7 +190,7 @@ func (log *Logger) Info(msg string, fields ...zapcore.Field) {
 
 // Warn logs a message at WarnLevel. The message includes any fields passed
 // at the log site, as well as any fields accumulated on the logger.
-func (log *Logger) Warn(msg string, fields ...zapcore.Field) {
+func (log *Logger) Warn(msg string, fields ...Field) {
 	if ce := log.check(WarnLevel, msg); ce != nil {
 		ce.Write(fields...)
 	}
@@ -198,7 +198,7 @@ func (log *Logger) Warn(msg string, fields ...zapcore.Field) {
 
 // Error logs a message at ErrorLevel. The message includes any fields passed
 // at the log site, as well as any fields accumulated on the logger.
-func (log *Logger) Error(msg string, fields ...zapcore.Field) {
+func (log *Logger) Error(msg string, fields ...Field) {
 	if ce := log.check(ErrorLevel, msg); ce != nil {
 		ce.Write(fields...)
 	}
@@ -210,7 +210,7 @@ func (log *Logger) Error(msg string, fields ...zapcore.Field) {
 // If the logger is in development mode, it then panics (DPanic means
 // "development panic"). This is useful for catching errors that are
 // recoverable, but shouldn't ever happen.
-func (log *Logger) DPanic(msg string, fields ...zapcore.Field) {
+func (log *Logger) DPanic(msg string, fields ...Field) {
 	if ce := log.check(DPanicLevel, msg); ce != nil {
 		ce.Write(fields...)
 	}
@@ -220,7 +220,7 @@ func (log *Logger) DPanic(msg string, fields ...zapcore.Field) {
 // at the log site, as well as any fields accumulated on the logger.
 //
 // The logger then panics, even if logging at PanicLevel is disabled.
-func (log *Logger) Panic(msg string, fields ...zapcore.Field) {
+func (log *Logger) Panic(msg string, fields ...Field) {
 	if ce := log.check(PanicLevel, msg); ce != nil {
 		ce.Write(fields...)
 	}
@@ -231,7 +231,7 @@ func (log *Logger) Panic(msg string, fields ...zapcore.Field) {
 //
 // The logger then calls os.Exit(1), even if logging at FatalLevel is
 // disabled.
-func (log *Logger) Fatal(msg string, fields ...zapcore.Field) {
+func (log *Logger) Fatal(msg string, fields ...Field) {
 	if ce := log.check(FatalLevel, msg); ce != nil {
 		ce.Write(fields...)
 	}

--- a/vendor/go.uber.org/zap/logger_bench_test.go
+++ b/vendor/go.uber.org/zap/logger_bench_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap/internal/ztest"
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 )
 
 type user struct {
@@ -52,7 +52,7 @@ func withBenchedLogger(b *testing.B, f func(*Logger)) {
 	logger := New(
 		zapcore.NewCore(
 			zapcore.NewJSONEncoder(NewProductionConfig().EncoderConfig),
-			&zaptest.Discarder{},
+			&ztest.Discarder{},
 			DebugLevel,
 		))
 	b.ResetTimer()
@@ -166,7 +166,7 @@ func BenchmarkAddCallerHook(b *testing.B) {
 	logger := New(
 		zapcore.NewCore(
 			zapcore.NewJSONEncoder(NewProductionConfig().EncoderConfig),
-			&zaptest.Discarder{},
+			&ztest.Discarder{},
 			InfoLevel,
 		),
 		AddCaller(),
@@ -200,15 +200,15 @@ func Benchmark100Fields(b *testing.B) {
 	const batchSize = 50
 	logger := New(zapcore.NewCore(
 		zapcore.NewJSONEncoder(NewProductionConfig().EncoderConfig),
-		&zaptest.Discarder{},
+		&ztest.Discarder{},
 		DebugLevel,
 	))
 
 	// Don't include allocating these helper slices in the benchmark. Since
 	// access to them isn't synchronized, we can't run the benchmark in
 	// parallel.
-	first := make([]zapcore.Field, batchSize)
-	second := make([]zapcore.Field, batchSize)
+	first := make([]Field, batchSize)
+	second := make([]Field, batchSize)
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {

--- a/vendor/go.uber.org/zap/options.go
+++ b/vendor/go.uber.org/zap/options.go
@@ -55,7 +55,7 @@ func Hooks(hooks ...func(zapcore.Entry) error) Option {
 }
 
 // Fields adds fields to the Logger.
-func Fields(fs ...zapcore.Field) Option {
+func Fields(fs ...Field) Option {
 	return optionFunc(func(log *Logger) {
 		log.core = log.core.With(fs)
 	})

--- a/vendor/go.uber.org/zap/stacktrace_ext_test.go
+++ b/vendor/go.uber.org/zap/stacktrace_ext_test.go
@@ -101,7 +101,10 @@ func TestStacktraceFiltersVendorZap(t *testing.T) {
 		// Set up symlinks for zap, and for any test dependencies.
 		setupSymlink(t, curDir, filepath.Join(vendorDir, "go.uber.org/zap"))
 		for _, testDep := range []string{"github.com/stretchr/testify"} {
-			setupSymlink(t, filepath.Join(curDir, "vendor", testDep), filepath.Join(vendorDir, testDep))
+			target := filepath.Join(curDir, "vendor", testDep)
+			_, err := os.Stat(target)
+			require.NoError(t, err, "Required dependency (%v) not installed in vendor", target)
+			setupSymlink(t, target, filepath.Join(vendorDir, testDep))
 		}
 
 		// Now run the above test which ensures we filter out zap stacktraces, but this time

--- a/vendor/go.uber.org/zap/sugar.go
+++ b/vendor/go.uber.org/zap/sugar.go
@@ -62,9 +62,9 @@ func (s *SugaredLogger) Named(name string) *SugaredLogger {
 }
 
 // With adds a variadic number of fields to the logging context. It accepts a
-// mix of strongly-typed zapcore.Field objects and loosely-typed key-value
-// pairs. When processing pairs, the first element of the pair is used as the
-// field key and the second as the field value.
+// mix of strongly-typed Field objects and loosely-typed key-value pairs. When
+// processing pairs, the first element of the pair is used as the field key
+// and the second as the field value.
 //
 // For example,
 //   sugaredLogger.With(
@@ -235,19 +235,19 @@ func (s *SugaredLogger) log(lvl zapcore.Level, template string, fmtArgs []interf
 	}
 }
 
-func (s *SugaredLogger) sweetenFields(args []interface{}) []zapcore.Field {
+func (s *SugaredLogger) sweetenFields(args []interface{}) []Field {
 	if len(args) == 0 {
 		return nil
 	}
 
 	// Allocate enough space for the worst case; if users pass only structured
 	// fields, we shouldn't penalize them with extra allocations.
-	fields := make([]zapcore.Field, 0, len(args))
+	fields := make([]Field, 0, len(args))
 	var invalid invalidPairs
 
 	for i := 0; i < len(args); {
 		// This is a strongly-typed field. Consume it and move on.
-		if f, ok := args[i].(zapcore.Field); ok {
+		if f, ok := args[i].(Field); ok {
 			fields = append(fields, f)
 			i++
 			continue

--- a/vendor/go.uber.org/zap/sugar_test.go
+++ b/vendor/go.uber.org/zap/sugar_test.go
@@ -24,8 +24,8 @@ import (
 	"testing"
 
 	"go.uber.org/zap/internal/exit"
+	"go.uber.org/zap/internal/ztest"
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
@@ -37,86 +37,86 @@ func TestSugarWith(t *testing.T) {
 	ignored := func(msg interface{}) observer.LoggedEntry {
 		return observer.LoggedEntry{
 			Entry:   zapcore.Entry{Level: DPanicLevel, Message: _oddNumberErrMsg},
-			Context: []zapcore.Field{Any("ignored", msg)},
+			Context: []Field{Any("ignored", msg)},
 		}
 	}
 	nonString := func(pairs ...invalidPair) observer.LoggedEntry {
 		return observer.LoggedEntry{
 			Entry:   zapcore.Entry{Level: DPanicLevel, Message: _nonStringKeyErrMsg},
-			Context: []zapcore.Field{Array("invalid", invalidPairs(pairs))},
+			Context: []Field{Array("invalid", invalidPairs(pairs))},
 		}
 	}
 
 	tests := []struct {
 		desc     string
 		args     []interface{}
-		expected []zapcore.Field
+		expected []Field
 		errLogs  []observer.LoggedEntry
 	}{
 		{
 			desc:     "nil args",
 			args:     nil,
-			expected: []zapcore.Field{},
+			expected: []Field{},
 			errLogs:  nil,
 		},
 		{
 			desc:     "empty slice of args",
 			args:     []interface{}{},
-			expected: []zapcore.Field{},
+			expected: []Field{},
 			errLogs:  nil,
 		},
 		{
 			desc:     "just a dangling key",
 			args:     []interface{}{"should ignore"},
-			expected: []zapcore.Field{},
+			expected: []Field{},
 			errLogs:  []observer.LoggedEntry{ignored("should ignore")},
 		},
 		{
 			desc:     "well-formed key-value pairs",
 			args:     []interface{}{"foo", 42, "true", "bar"},
-			expected: []zapcore.Field{Int("foo", 42), String("true", "bar")},
+			expected: []Field{Int("foo", 42), String("true", "bar")},
 			errLogs:  nil,
 		},
 		{
 			desc:     "just a structured field",
 			args:     []interface{}{Int("foo", 42)},
-			expected: []zapcore.Field{Int("foo", 42)},
+			expected: []Field{Int("foo", 42)},
 			errLogs:  nil,
 		},
 		{
 			desc:     "structured field and a dangling key",
 			args:     []interface{}{Int("foo", 42), "dangling"},
-			expected: []zapcore.Field{Int("foo", 42)},
+			expected: []Field{Int("foo", 42)},
 			errLogs:  []observer.LoggedEntry{ignored("dangling")},
 		},
 		{
 			desc:     "structured field and a dangling non-string key",
 			args:     []interface{}{Int("foo", 42), 13},
-			expected: []zapcore.Field{Int("foo", 42)},
+			expected: []Field{Int("foo", 42)},
 			errLogs:  []observer.LoggedEntry{ignored(13)},
 		},
 		{
 			desc:     "key-value pair and a dangling key",
 			args:     []interface{}{"foo", 42, "dangling"},
-			expected: []zapcore.Field{Int("foo", 42)},
+			expected: []Field{Int("foo", 42)},
 			errLogs:  []observer.LoggedEntry{ignored("dangling")},
 		},
 		{
 			desc:     "pairs, a structured field, and a dangling key",
 			args:     []interface{}{"first", "field", Int("foo", 42), "baz", "quux", "dangling"},
-			expected: []zapcore.Field{String("first", "field"), Int("foo", 42), String("baz", "quux")},
+			expected: []Field{String("first", "field"), Int("foo", 42), String("baz", "quux")},
 			errLogs:  []observer.LoggedEntry{ignored("dangling")},
 		},
 		{
 			desc:     "one non-string key",
 			args:     []interface{}{"foo", 42, true, "bar"},
-			expected: []zapcore.Field{Int("foo", 42)},
+			expected: []Field{Int("foo", 42)},
 			errLogs:  []observer.LoggedEntry{nonString(invalidPair{2, true, "bar"})},
 		},
 		{
 			desc:     "pairs, structured fields, non-string keys, and a dangling key",
 			args:     []interface{}{"foo", 42, true, "bar", Int("structure", 11), 42, "reversed", "baz", "quux", "dangling"},
-			expected: []zapcore.Field{Int("foo", 42), Int("structure", 11), String("baz", "quux")},
+			expected: []Field{Int("foo", 42), Int("structure", 11), String("baz", "quux")},
 			errLogs: []observer.LoggedEntry{
 				ignored("dangling"),
 				nonString(invalidPair{2, true, "bar"}, invalidPair{5, 42, "reversed"}),
@@ -146,7 +146,7 @@ func TestSugarFieldsInvalidPairs(t *testing.T) {
 
 		// Double-check that the actual message was logged.
 		require.Equal(t, 2, len(output), "Unexpected number of entries logged.")
-		require.Equal(t, observer.LoggedEntry{Context: []zapcore.Field{}}, output[1], "Unexpected non-error log entry.")
+		require.Equal(t, observer.LoggedEntry{Context: []Field{}}, output[1], "Unexpected non-error log entry.")
 
 		// Assert that the error message's structured fields serialize properly.
 		require.Equal(t, 1, len(output[0].Context), "Expected one field in error entry context.")
@@ -175,7 +175,7 @@ func TestSugarStructuredLogging(t *testing.T) {
 	// Common to all test cases.
 	context := []interface{}{"foo", "bar"}
 	extra := []interface{}{"baz", false}
-	expectedFields := []zapcore.Field{String("foo", "bar"), Bool("baz", false)}
+	expectedFields := []Field{String("foo", "bar"), Bool("baz", false)}
 
 	for _, tt := range tests {
 		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
@@ -207,7 +207,7 @@ func TestSugarConcatenatingLogging(t *testing.T) {
 
 	// Common to all test cases.
 	context := []interface{}{"foo", "bar"}
-	expectedFields := []zapcore.Field{String("foo", "bar")}
+	expectedFields := []Field{String("foo", "bar")}
 
 	for _, tt := range tests {
 		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
@@ -243,7 +243,7 @@ func TestSugarTemplatedLogging(t *testing.T) {
 
 	// Common to all test cases.
 	context := []interface{}{"foo", "bar"}
-	expectedFields := []zapcore.Field{String("foo", "bar")}
+	expectedFields := []Field{String("foo", "bar")}
 
 	for _, tt := range tests {
 		withSugar(t, DebugLevel, nil, func(logger *SugaredLogger, logs *observer.ObservedLogs) {
@@ -287,7 +287,7 @@ func TestSugarPanicLogging(t *testing.T) {
 			assert.Panics(t, func() { tt.f(sugar) }, "Expected panic-level logger calls to panic.")
 			if tt.expectedMsg != "" {
 				assert.Equal(t, []observer.LoggedEntry{{
-					Context: []zapcore.Field{},
+					Context: []Field{},
 					Entry:   zapcore.Entry{Message: tt.expectedMsg, Level: PanicLevel},
 				}}, logs.AllUntimed(), "Unexpected log output.")
 			} else {
@@ -320,7 +320,7 @@ func TestSugarFatalLogging(t *testing.T) {
 			assert.True(t, stub.Exited, "Expected all calls to fatal logger methods to exit process.")
 			if tt.expectedMsg != "" {
 				assert.Equal(t, []observer.LoggedEntry{{
-					Context: []zapcore.Field{},
+					Context: []Field{},
 					Entry:   zapcore.Entry{Message: tt.expectedMsg, Level: FatalLevel},
 				}}, logs.AllUntimed(), "Unexpected log output.")
 			} else {
@@ -356,7 +356,7 @@ func TestSugarAddCaller(t *testing.T) {
 }
 
 func TestSugarAddCallerFail(t *testing.T) {
-	errBuf := &zaptest.Buffer{}
+	errBuf := &ztest.Buffer{}
 	withSugar(t, DebugLevel, opts(AddCaller(), AddCallerSkip(1e3), ErrorOutput(errBuf)), func(log *SugaredLogger, logs *observer.ObservedLogs) {
 		log.Info("Failure.")
 		assert.Regexp(

--- a/vendor/go.uber.org/zap/zapcore/core_test.go
+++ b/vendor/go.uber.org/zap/zapcore/core_test.go
@@ -27,8 +27,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap/internal/ztest"
 	. "go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -106,7 +106,7 @@ func TestIOCore(t *testing.T) {
 }
 
 func TestIOCoreSyncFail(t *testing.T) {
-	sink := &zaptest.Discarder{}
+	sink := &ztest.Discarder{}
 	err := errors.New("failed")
 	sink.SetError(err)
 
@@ -139,7 +139,7 @@ func TestIOCoreSyncsOutput(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		sink := &zaptest.Discarder{}
+		sink := &ztest.Discarder{}
 		core := NewCore(
 			NewJSONEncoder(testEncoderConfig()),
 			sink,
@@ -154,7 +154,7 @@ func TestIOCoreSyncsOutput(t *testing.T) {
 func TestIOCoreWriteFailure(t *testing.T) {
 	core := NewCore(
 		NewJSONEncoder(testEncoderConfig()),
-		Lock(&zaptest.FailWriter{}),
+		Lock(&ztest.FailWriter{}),
 		DebugLevel,
 	)
 	err := core.Write(Entry{}, nil)

--- a/vendor/go.uber.org/zap/zapcore/json_encoder_impl_test.go
+++ b/vendor/go.uber.org/zap/zapcore/json_encoder_impl_test.go
@@ -223,7 +223,9 @@ func TestJSONEncoderObjectFields(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		assertOutput(t, tt.desc, tt.expected, tt.f)
+		t.Run(tt.desc, func(t *testing.T) {
+			assertOutput(t, tt.expected, tt.f)
+		})
 	}
 }
 
@@ -314,16 +316,18 @@ func TestJSONEncoderArrays(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		f := func(enc Encoder) error {
-			return enc.AddArray("array", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
-				tt.f(arr)
-				tt.f(arr)
-				return nil
-			}))
-		}
-		assertOutput(t, tt.desc, `"array":`+tt.expected, func(enc Encoder) {
-			err := f(enc)
-			assert.NoError(t, err, "Unexpected error adding array to JSON encoder.")
+		t.Run(tt.desc, func(t *testing.T) {
+			f := func(enc Encoder) error {
+				return enc.AddArray("array", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
+					tt.f(arr)
+					tt.f(arr)
+					return nil
+				}))
+			}
+			assertOutput(t, `"array":`+tt.expected, func(enc Encoder) {
+				err := f(enc)
+				assert.NoError(t, err, "Unexpected error adding array to JSON encoder.")
+			})
 		})
 	}
 }
@@ -332,13 +336,13 @@ func assertJSON(t *testing.T, expected string, enc *jsonEncoder) {
 	assert.Equal(t, expected, enc.buf.String(), "Encoded JSON didn't match expectations.")
 }
 
-func assertOutput(t testing.TB, desc string, expected string, f func(Encoder)) {
+func assertOutput(t testing.TB, expected string, f func(Encoder)) {
 	enc := &jsonEncoder{buf: bufferpool.Get(), EncoderConfig: &EncoderConfig{
 		EncodeTime:     EpochTimeEncoder,
 		EncodeDuration: SecondsDurationEncoder,
 	}}
 	f(enc)
-	assert.Equal(t, expected, enc.buf.String(), "Unexpected encoder output after adding a %s.", desc)
+	assert.Equal(t, expected, enc.buf.String(), "Unexpected encoder output after adding.")
 
 	enc.truncate()
 	enc.AddString("foo", "bar")
@@ -349,7 +353,7 @@ func assertOutput(t testing.TB, desc string, expected string, f func(Encoder)) {
 		// field.
 		expectedPrefix += ","
 	}
-	assert.Equal(t, expectedPrefix+expected, enc.buf.String(), "Unexpected encoder output after adding a %s as a second field.", desc)
+	assert.Equal(t, expectedPrefix+expected, enc.buf.String(), "Unexpected encoder output after adding as a second field.")
 }
 
 // Nested Array- and ObjectMarshalers.

--- a/vendor/go.uber.org/zap/zapcore/memory_encoder_test.go
+++ b/vendor/go.uber.org/zap/zapcore/memory_encoder_test.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMapObjectEncoderAdd(t *testing.T) {
@@ -204,9 +205,11 @@ func TestMapObjectEncoderAdd(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		enc := NewMapObjectEncoder()
-		tt.f(enc)
-		assert.Equal(t, tt.expected, enc.Fields["k"], "Unexpected encoder output.")
+		t.Run(tt.desc, func(t *testing.T) {
+			enc := NewMapObjectEncoder()
+			tt.f(enc)
+			assert.Equal(t, tt.expected, enc.Fields["k"], "Unexpected encoder output.")
+		})
 	}
 }
 func TestSliceArrayEncoderAppend(t *testing.T) {
@@ -255,19 +258,18 @@ func TestSliceArrayEncoderAppend(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		enc := NewMapObjectEncoder()
-		assert.NoError(t, enc.AddArray("k", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
-			tt.f(arr)
-			tt.f(arr)
-			return nil
-		})), "Expected AddArray to succeed.")
+		t.Run(tt.desc, func(t *testing.T) {
+			enc := NewMapObjectEncoder()
+			assert.NoError(t, enc.AddArray("k", ArrayMarshalerFunc(func(arr ArrayEncoder) error {
+				tt.f(arr)
+				tt.f(arr)
+				return nil
+			})), "Expected AddArray to succeed.")
 
-		arr, ok := enc.Fields["k"].([]interface{})
-		if !ok {
-			t.Errorf("Test case %s didn't encode an array.", tt.desc)
-			continue
-		}
-		assert.Equal(t, []interface{}{tt.expected, tt.expected}, arr, "Unexpected encoder output.")
+			arr, ok := enc.Fields["k"].([]interface{})
+			require.True(t, ok, "Test case %s didn't encode an array.", tt.desc)
+			assert.Equal(t, []interface{}{tt.expected, tt.expected}, arr, "Unexpected encoder output.")
+		})
 	}
 }
 

--- a/vendor/go.uber.org/zap/zapcore/sampler_bench_test.go
+++ b/vendor/go.uber.org/zap/zapcore/sampler_bench_test.go
@@ -25,8 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/zap/internal/ztest"
 	. "go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 )
 
 var counterTestCases = [][]string{
@@ -206,7 +206,7 @@ func BenchmarkSampler_Check(b *testing.B) {
 			fac := NewSampler(
 				NewCore(
 					NewJSONEncoder(testEncoderConfig()),
-					&zaptest.Discarder{},
+					&ztest.Discarder{},
 					DebugLevel,
 				),
 				time.Millisecond, 1, 1000)

--- a/vendor/go.uber.org/zap/zapcore/sampler_test.go
+++ b/vendor/go.uber.org/zap/zapcore/sampler_test.go
@@ -27,8 +27,8 @@ import (
 	"time"
 
 	"go.uber.org/atomic"
+	"go.uber.org/zap/internal/ztest"
 	. "go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
@@ -105,7 +105,7 @@ func TestSamplerTicking(t *testing.T) {
 		for i := 1; i <= 5; i++ {
 			writeSequence(sampler, i, InfoLevel)
 		}
-		zaptest.Sleep(15 * time.Millisecond)
+		ztest.Sleep(15 * time.Millisecond)
 	}
 	assertSequence(
 		t,
@@ -121,7 +121,7 @@ func TestSamplerTicking(t *testing.T) {
 		for i := 1; i < 18; i++ {
 			writeSequence(sampler, i, InfoLevel)
 		}
-		zaptest.Sleep(10 * time.Millisecond)
+		ztest.Sleep(10 * time.Millisecond)
 	}
 
 	assertSequence(
@@ -160,7 +160,7 @@ func TestSamplerConcurrent(t *testing.T) {
 		expectedCount = numMessages * logsPerTick * numTicks
 	)
 
-	tick := zaptest.Timeout(10 * time.Millisecond)
+	tick := ztest.Timeout(10 * time.Millisecond)
 	cc := &countingCore{}
 	sampler := NewSampler(cc, tick, logsPerTick, 100000)
 

--- a/vendor/go.uber.org/zap/zapcore/tee_logger_bench_test.go
+++ b/vendor/go.uber.org/zap/zapcore/tee_logger_bench_test.go
@@ -23,14 +23,14 @@ package zapcore_test
 import (
 	"testing"
 
+	"go.uber.org/zap/internal/ztest"
 	. "go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 )
 
 func withBenchedTee(b *testing.B, f func(Core)) {
 	fac := NewTee(
-		NewCore(NewJSONEncoder(testEncoderConfig()), &zaptest.Discarder{}, DebugLevel),
-		NewCore(NewJSONEncoder(testEncoderConfig()), &zaptest.Discarder{}, InfoLevel),
+		NewCore(NewJSONEncoder(testEncoderConfig()), &ztest.Discarder{}, DebugLevel),
+		NewCore(NewJSONEncoder(testEncoderConfig()), &ztest.Discarder{}, InfoLevel),
 	)
 	b.ResetTimer()
 	f(fac)

--- a/vendor/go.uber.org/zap/zapcore/tee_test.go
+++ b/vendor/go.uber.org/zap/zapcore/tee_test.go
@@ -24,8 +24,8 @@ import (
 	"errors"
 	"testing"
 
+	"go.uber.org/zap/internal/ztest"
 	. "go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/stretchr/testify/assert"
@@ -139,7 +139,7 @@ func TestTeeSync(t *testing.T) {
 	tee := NewTee(infoLogger, warnLogger)
 	assert.NoError(t, tee.Sync(), "Unexpected error from Syncing a tee.")
 
-	sink := &zaptest.Discarder{}
+	sink := &ztest.Discarder{}
 	err := errors.New("failed")
 	sink.SetError(err)
 

--- a/vendor/go.uber.org/zap/zaptest/doc.go
+++ b/vendor/go.uber.org/zap/zaptest/doc.go
@@ -18,10 +18,5 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-// Package zaptest provides low-level helpers for testing log output. These
-// utilities are helpful in zap's own unit tests, but any assertions using
-// them are strongly coupled to a single encoding.
-//
-// Most users should use go.uber.org/zap/zaptest/observer instead of this
-// package.
+// Package zaptest provides a variety of helpers for testing log output.
 package zaptest // import "go.uber.org/zap/zaptest"

--- a/vendor/go.uber.org/zap/zaptest/logger.go
+++ b/vendor/go.uber.org/zap/zaptest/logger.go
@@ -1,0 +1,124 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+import (
+	"bytes"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+// LoggerOption configures the test logger built by NewLogger.
+type LoggerOption interface {
+	applyLoggerOption(*loggerOptions)
+}
+
+type loggerOptions struct {
+	Level zapcore.LevelEnabler
+}
+
+type loggerOptionFunc func(*loggerOptions)
+
+func (f loggerOptionFunc) applyLoggerOption(opts *loggerOptions) {
+	f(opts)
+}
+
+// Level controls which messages are logged by a test Logger built by
+// NewLogger.
+func Level(enab zapcore.LevelEnabler) LoggerOption {
+	return loggerOptionFunc(func(opts *loggerOptions) {
+		opts.Level = enab
+	})
+}
+
+// NewLogger builds a new Logger that logs all messages to the given
+// testing.TB.
+//
+//   logger := zaptest.NewLogger(t)
+//
+// Use this with a *testing.T or *testing.B to get logs which get printed only
+// if a test fails or if you ran go test -v.
+//
+// The returned logger defaults to logging debug level messages and above.
+// This may be changd by passing a zaptest.Level during construction.
+//
+//   logger := zaptest.NewLogger(t, zaptest.Level(zap.WarnLevel))
+func NewLogger(t TestingT, opts ...LoggerOption) *zap.Logger {
+	cfg := loggerOptions{
+		Level: zapcore.DebugLevel,
+	}
+	for _, o := range opts {
+		o.applyLoggerOption(&cfg)
+	}
+
+	writer := newTestingWriter(t)
+	return zap.New(
+		zapcore.NewCore(
+			zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
+			writer,
+			cfg.Level,
+		),
+
+		// Send zap errors to the same writer and mark the test as failed if
+		// that happens.
+		zap.ErrorOutput(writer.WithMarkFailed(true)),
+	)
+}
+
+// testingWriter is a WriteSyncer that writes to the given testing.TB.
+type testingWriter struct {
+	t TestingT
+
+	// If true, the test will be marked as failed if this testingWriter is
+	// ever used.
+	markFailed bool
+}
+
+func newTestingWriter(t TestingT) testingWriter {
+	return testingWriter{t: t}
+}
+
+// WithMarkFailed returns a copy of this testingWriter with markFailed set to
+// the provided value.
+func (w testingWriter) WithMarkFailed(v bool) testingWriter {
+	w.markFailed = v
+	return w
+}
+
+func (w testingWriter) Write(p []byte) (n int, err error) {
+	n = len(p)
+
+	// Strip trailing newline because t.Log always adds one.
+	p = bytes.TrimRight(p, "\n")
+
+	// Note: t.Log is safe for concurrent use.
+	w.t.Logf("%s", p)
+	if w.markFailed {
+		w.t.Fail()
+	}
+
+	return n, nil
+}
+
+func (w testingWriter) Sync() error {
+	return nil
+}

--- a/vendor/go.uber.org/zap/zaptest/logger_test.go
+++ b/vendor/go.uber.org/zap/zaptest/logger_test.go
@@ -1,0 +1,169 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/internal/ztest"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTestLogger(t *testing.T) {
+	ts := newTestLogSpy(t)
+	defer ts.AssertPassed()
+
+	log := NewLogger(ts)
+
+	log.Info("received work order")
+	log.Debug("starting work")
+	log.Warn("work may fail")
+	log.Error("work failed", zap.Error(errors.New("great sadness")))
+
+	assert.Panics(t, func() {
+		log.Panic("failed to do work")
+	}, "log.Panic should panic")
+
+	ts.AssertMessages(
+		"INFO	received work order",
+		"DEBUG	starting work",
+		"WARN	work may fail",
+		`ERROR	work failed	{"error": "great sadness"}`,
+		"PANIC	failed to do work",
+	)
+}
+
+func TestTestLoggerSupportsLevels(t *testing.T) {
+	ts := newTestLogSpy(t)
+	defer ts.AssertPassed()
+
+	log := NewLogger(ts, Level(zap.WarnLevel))
+
+	log.Info("received work order")
+	log.Debug("starting work")
+	log.Warn("work may fail")
+	log.Error("work failed", zap.Error(errors.New("great sadness")))
+
+	assert.Panics(t, func() {
+		log.Panic("failed to do work")
+	}, "log.Panic should panic")
+
+	ts.AssertMessages(
+		"WARN	work may fail",
+		`ERROR	work failed	{"error": "great sadness"}`,
+		"PANIC	failed to do work",
+	)
+}
+
+func TestTestingWriter(t *testing.T) {
+	ts := newTestLogSpy(t)
+	w := newTestingWriter(ts)
+
+	n, err := io.WriteString(w, "hello\n\n")
+	assert.NoError(t, err, "WriteString must not fail")
+	assert.Equal(t, 7, n)
+}
+
+func TestTestLoggerErrorOutput(t *testing.T) {
+	// This test verifies that the test logger logs internal messages to the
+	// testing.T and marks the test as failed.
+
+	ts := newTestLogSpy(t)
+	defer ts.AssertFailed()
+
+	log := NewLogger(ts)
+
+	// Replace with a core that fails.
+	log = log.WithOptions(zap.WrapCore(func(zapcore.Core) zapcore.Core {
+		return zapcore.NewCore(
+			zapcore.NewConsoleEncoder(zap.NewDevelopmentEncoderConfig()),
+			zapcore.Lock(zapcore.AddSync(ztest.FailWriter{})),
+			zapcore.DebugLevel,
+		)
+	}))
+
+	log.Info("foo") // this fails
+
+	if assert.Len(t, ts.Messages, 1, "expected a log message") {
+		assert.Regexp(t, `write error: failed`, ts.Messages[0])
+	}
+}
+
+// testLogSpy is a testing.TB that captures logged messages.
+type testLogSpy struct {
+	testing.TB
+
+	failed   bool
+	Messages []string
+}
+
+func newTestLogSpy(t testing.TB) *testLogSpy {
+	return &testLogSpy{TB: t}
+}
+
+func (t *testLogSpy) Fail() {
+	t.failed = true
+}
+
+func (t *testLogSpy) Failed() bool {
+	return t.failed
+}
+
+func (t *testLogSpy) FailNow() {
+	t.Fail()
+	t.TB.FailNow()
+}
+
+func (t *testLogSpy) Logf(format string, args ...interface{}) {
+	// Log messages are in the format,
+	//
+	//   2017-10-27T13:03:01.000-0700	DEBUG	your message here	{data here}
+	//
+	// We strip the first part of these messages because we can't really test
+	// for the timestamp from these tests.
+	m := fmt.Sprintf(format, args...)
+	m = m[strings.IndexByte(m, '\t')+1:]
+	t.Messages = append(t.Messages, m)
+	t.TB.Log(m)
+}
+
+func (t *testLogSpy) AssertMessages(msgs ...string) {
+	assert.Equal(t.TB, msgs, t.Messages, "logged messages did not match")
+}
+
+func (t *testLogSpy) AssertPassed() {
+	t.assertFailed(false, "expected test to pass")
+}
+
+func (t *testLogSpy) AssertFailed() {
+	t.assertFailed(true, "expected test to fail")
+}
+
+func (t *testLogSpy) assertFailed(v bool, msg string) {
+	assert.Equal(t.TB, v, t.failed, msg)
+}

--- a/vendor/go.uber.org/zap/zaptest/testingt.go
+++ b/vendor/go.uber.org/zap/zaptest/testingt.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,39 +18,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package zapcore
+package zaptest
 
-import (
-	"testing"
+// TestingT is a subset of the API provided by all *testing.T and *testing.B
+// objects.
+type TestingT interface {
+	// Logs the given message without failing the test.
+	Logf(string, ...interface{})
 
-	"go.uber.org/zap/internal/ztest"
-)
+	// Logs the given message and marks the test as failed.
+	Errorf(string, ...interface{})
 
-func BenchmarkMultiWriteSyncer(b *testing.B) {
-	b.Run("2", func(b *testing.B) {
-		w := NewMultiWriteSyncer(
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-		)
-		b.ResetTimer()
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				w.Write([]byte("foobarbazbabble"))
-			}
-		})
-	})
-	b.Run("4", func(b *testing.B) {
-		w := NewMultiWriteSyncer(
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-		)
-		b.ResetTimer()
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				w.Write([]byte("foobarbazbabble"))
-			}
-		})
-	})
+	// Marks the test as failed.
+	Fail()
+
+	// Returns true if the test has been marked as failed.
+	Failed() bool
+
+	// Returns the name of the test.
+	Name() string
+
+	// Marks the test as failed and stops execution of that test.
+	FailNow()
 }
+
+// Note: We currently only rely on Logf. We are including Errorf and FailNow
+// in the interface in anticipation of future need since we can't extend the
+// interface without a breaking change.

--- a/vendor/go.uber.org/zap/zaptest/testingt_test.go
+++ b/vendor/go.uber.org/zap/zaptest/testingt_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2016 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -18,39 +18,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package zapcore
+package zaptest
 
-import (
-	"testing"
+import "testing"
 
-	"go.uber.org/zap/internal/ztest"
-)
+// Just a compile-time test to ensure that TestingT matches the testing.TB
+// interface. We could do this in testingt.go but that would put a dependency
+// on the "testing" package from zaptest.
 
-func BenchmarkMultiWriteSyncer(b *testing.B) {
-	b.Run("2", func(b *testing.B) {
-		w := NewMultiWriteSyncer(
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-		)
-		b.ResetTimer()
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				w.Write([]byte("foobarbazbabble"))
-			}
-		})
-	})
-	b.Run("4", func(b *testing.B) {
-		w := NewMultiWriteSyncer(
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-		)
-		b.ResetTimer()
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				w.Write([]byte("foobarbazbabble"))
-			}
-		})
-	})
-}
+var _ TestingT = (testing.TB)(nil)

--- a/vendor/go.uber.org/zap/zaptest/timeout.go
+++ b/vendor/go.uber.org/zap/zaptest/timeout.go
@@ -21,31 +21,25 @@
 package zaptest
 
 import (
-	"log"
-	"os"
-	"strconv"
 	"time"
+
+	"go.uber.org/zap/internal/ztest"
 )
 
-var _timeoutScale = 1.0
-
 // Timeout scales the provided duration by $TEST_TIMEOUT_SCALE.
+//
+// Deprecated: This function is intended for internal testing and shouldn't be
+// used outside zap itself. It was introduced before Go supported internal
+// packages.
 func Timeout(base time.Duration) time.Duration {
-	return time.Duration(float64(base) * _timeoutScale)
+	return ztest.Timeout(base)
 }
 
 // Sleep scales the sleep duration by $TEST_TIMEOUT_SCALE.
+//
+// Deprecated: This function is intended for internal testing and shouldn't be
+// used outside zap itself. It was introduced before Go supported internal
+// packages.
 func Sleep(base time.Duration) {
-	time.Sleep(Timeout(base))
-}
-
-func init() {
-	if v := os.Getenv("TEST_TIMEOUT_SCALE"); v != "" {
-		fv, err := strconv.ParseFloat(v, 64)
-		if err != nil {
-			panic(err)
-		}
-		_timeoutScale = fv
-		log.Printf("Scaling timeouts by %vx.\n", _timeoutScale)
-	}
+	ztest.Sleep(base)
 }

--- a/vendor/go.uber.org/zap/zaptest/timeout_test.go
+++ b/vendor/go.uber.org/zap/zaptest/timeout_test.go
@@ -18,39 +18,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package zapcore
+package zaptest
 
 import (
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap/internal/ztest"
 )
 
-func BenchmarkMultiWriteSyncer(b *testing.B) {
-	b.Run("2", func(b *testing.B) {
-		w := NewMultiWriteSyncer(
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-		)
-		b.ResetTimer()
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				w.Write([]byte("foobarbazbabble"))
-			}
-		})
-	})
-	b.Run("4", func(b *testing.B) {
-		w := NewMultiWriteSyncer(
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-			&ztest.Discarder{},
-		)
-		b.ResetTimer()
-		b.RunParallel(func(pb *testing.PB) {
-			for pb.Next() {
-				w.Write([]byte("foobarbazbabble"))
-			}
-		})
-	})
+func TestTimeout(t *testing.T) {
+	defer ztest.Initialize("2")()
+	assert.Equal(t, time.Duration(100), Timeout(50), "Expected to scale up timeout.")
+}
+
+func TestSleep(t *testing.T) {
+	defer ztest.Initialize("2")()
+	const sleepFor = 50 * time.Millisecond
+	now := time.Now()
+	Sleep(sleepFor)
+	elapsed := time.Since(now)
+	assert.True(t, 2*sleepFor <= elapsed, "Expected to scale up timeout.")
 }

--- a/vendor/go.uber.org/zap/zaptest/writer.go
+++ b/vendor/go.uber.org/zap/zaptest/writer.go
@@ -20,77 +20,25 @@
 
 package zaptest
 
-import (
-	"bytes"
-	"errors"
-	"io/ioutil"
-	"strings"
+import "go.uber.org/zap/internal/ztest"
+
+type (
+	// A Syncer is a spy for the Sync portion of zapcore.WriteSyncer.
+	Syncer = ztest.Syncer
+
+	// A Discarder sends all writes to ioutil.Discard.
+	Discarder = ztest.Discarder
+
+	// FailWriter is a WriteSyncer that always returns an error on writes.
+	FailWriter = ztest.FailWriter
+
+	// ShortWriter is a WriteSyncer whose write method never returns an error,
+	// but always reports that it wrote one byte less than the input slice's
+	// length (thus, a "short write").
+	ShortWriter = ztest.ShortWriter
+
+	// Buffer is an implementation of zapcore.WriteSyncer that sends all writes to
+	// a bytes.Buffer. It has convenience methods to split the accumulated buffer
+	// on newlines.
+	Buffer = ztest.Buffer
 )
-
-// A Syncer is a spy for the Sync portion of zapcore.WriteSyncer.
-type Syncer struct {
-	err    error
-	called bool
-}
-
-// SetError sets the error that the Sync method will return.
-func (s *Syncer) SetError(err error) {
-	s.err = err
-}
-
-// Sync records that it was called, then returns the user-supplied error (if
-// any).
-func (s *Syncer) Sync() error {
-	s.called = true
-	return s.err
-}
-
-// Called reports whether the Sync method was called.
-func (s *Syncer) Called() bool {
-	return s.called
-}
-
-// A Discarder sends all writes to ioutil.Discard.
-type Discarder struct{ Syncer }
-
-// Write implements io.Writer.
-func (d *Discarder) Write(b []byte) (int, error) {
-	return ioutil.Discard.Write(b)
-}
-
-// FailWriter is a WriteSyncer that always returns an error on writes.
-type FailWriter struct{ Syncer }
-
-// Write implements io.Writer.
-func (w FailWriter) Write(b []byte) (int, error) {
-	return len(b), errors.New("failed")
-}
-
-// ShortWriter is a WriteSyncer whose write method never fails, but
-// nevertheless fails to the last byte of the input.
-type ShortWriter struct{ Syncer }
-
-// Write implements io.Writer.
-func (w ShortWriter) Write(b []byte) (int, error) {
-	return len(b) - 1, nil
-}
-
-// Buffer is an implementation of zapcore.WriteSyncer that sends all writes to
-// a bytes.Buffer. It has convenience methods to split the accumulated buffer
-// on newlines.
-type Buffer struct {
-	bytes.Buffer
-	Syncer
-}
-
-// Lines returns the current buffer contents, split on newlines.
-func (b *Buffer) Lines() []string {
-	output := strings.Split(b.String(), "\n")
-	return output[:len(output)-1]
-}
-
-// Stripped returns the current buffer contents with the last trailing newline
-// stripped.
-func (b *Buffer) Stripped() string {
-	return strings.TrimRight(b.String(), "\n")
-}

--- a/vendor/go.uber.org/zap/zaptest/writer_test.go
+++ b/vendor/go.uber.org/zap/zaptest/writer_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package zaptest
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSyncer(t *testing.T) {
+	err := errors.New("sentinel")
+	s := &Syncer{}
+	s.SetError(err)
+	assert.Equal(t, err, s.Sync(), "Expected Sync to fail with provided error.")
+	assert.True(t, s.Called(), "Expected to record that Sync was called.")
+}
+
+func TestDiscarder(t *testing.T) {
+	d := &Discarder{}
+	payload := []byte("foo")
+	n, err := d.Write(payload)
+	assert.NoError(t, err, "Unexpected error writing to Discarder.")
+	assert.Equal(t, len(payload), n, "Wrong number of bytes written.")
+}
+
+func TestFailWriter(t *testing.T) {
+	w := &FailWriter{}
+	payload := []byte("foo")
+	n, err := w.Write(payload)
+	assert.Error(t, err, "Expected an error writing to FailWriter.")
+	assert.Equal(t, len(payload), n, "Wrong number of bytes written.")
+}
+
+func TestShortWriter(t *testing.T) {
+	w := &ShortWriter{}
+	payload := []byte("foo")
+	n, err := w.Write(payload)
+	assert.NoError(t, err, "Unexpected error writing to ShortWriter.")
+	assert.Equal(t, len(payload)-1, n, "Wrong number of bytes written.")
+}
+
+func TestBuffer(t *testing.T) {
+	buf := &Buffer{}
+	buf.WriteString("foo\n")
+	buf.WriteString("bar\n")
+	assert.Equal(t, []string{"foo", "bar"}, buf.Lines(), "Unexpected output from Lines.")
+	assert.Equal(t, "foo\nbar", buf.Stripped(), "Unexpected output from Stripped.")
+}


### PR DESCRIPTION
For `underpants-eb`, logs weren't getting sent to stderr. Updating zap fixed it, although unsure exactly why. Maybe related to [this](https://github.com/uber-go/zap/pull/508/files)

Updates zap from 1.7.1 to 1.8