### PR TITLE
Log http method when proxying requests

### DIFF
--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -124,6 +124,7 @@ func (b *Backend) serveHTTPProxy(w http.ResponseWriter, r *http.Request) {
 	zap.L().Info("proxying request",
 		zap.String("from", b.Route.From),
 		zap.String("uri", r.RequestURI),
+		zap.String("method", r.Method),
 		zap.String("dest", rebase.String()),
 		zap.String("user", u.Email))
 


### PR DESCRIPTION
Logging http methods will allow us to filter out GET requests from Kibana, reducing the amount of noise and adding valuable information.