### PR TITLE
cleanup proxy/deny logs, log as much context as possible

### DIFF
--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -64,7 +64,6 @@ func (b *Backend) serveHTTPProxy(w http.ResponseWriter, r *http.Request) {
 		zap.String("from", b.Route.From),
 		zap.String("uri", r.RequestURI),
 		zap.String("method", r.Method),
-		zap.String("body", bodyString),
 	}
 
 	u, err := user.DecodeFromRequest(r, b.Ctx.Key)
@@ -130,6 +129,7 @@ func (b *Backend) serveHTTPProxy(w http.ResponseWriter, r *http.Request) {
 
 	br.Body = ioutil.NopCloser(bytes.NewBuffer(bodyBytes))
 	bodyString := string(bodyBytes)
+	logFields = append(logFields, zap.String("body", bodyString))
 
 	zap.L().Info("proxying request", logFields...)
 	bp, err := http.DefaultTransport.RoundTrip(br)

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -70,9 +70,7 @@ func (b *Backend) serveHTTPProxy(w http.ResponseWriter, r *http.Request) {
 	u, err := user.DecodeFromRequest(r, b.Ctx.Key)
 	if err != nil {
 		zap.L().Info("authentication required. redirecting to auth provider", logFields...)
-		http.Redirect(w, r,
-			b.AuthProvider.GetAuthURL(b.Ctx, r),
-			http.StatusFound)
+		http.Redirect(w, r, b.AuthProvider.GetAuthURL(b.Ctx, r), http.StatusFound)
 		return
 	}
 	logFields = append(logFields, zap.String("user", u.Email))


### PR DESCRIPTION
This PR cleans up the way we are handling logs and adds more context. Specifically it ensures that the `from`, `uri`, and `method` fields get logged for every request, then more detailed log information is added as they become relevant.