### PR TITLE
add custom headers to requests, allow cross-subdomain cookies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,10 +8,31 @@
   version = "v0.17.0"
 
 [[projects]]
+  name = "github.com/davecgh/go-spew"
+  packages = ["spew"]
+  revision = "8991bc29aa16c548c550c7ff78260e27b9ab7c73"
+  version = "v1.1.1"
+
+[[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
   packages = ["proto"]
   revision = "1e59b77b52bf8e4b449a57e6f79f21226d571845"
+
+[[projects]]
+  name = "github.com/pmezard/go-difflib"
+  packages = ["difflib"]
+  revision = "792786c7400a136282c1664665ae0a8db921c6c2"
+  version = "v1.0.0"
+
+[[projects]]
+  name = "github.com/stretchr/testify"
+  packages = [
+    "assert",
+    "require"
+  ]
+  revision = "ffdc059bfe9ce6a4e144ba849dbedead332c6053"
+  version = "v1.3.0"
 
 [[projects]]
   name = "go.uber.org/atomic"
@@ -94,6 +115,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a3204d2da277dc7826d4c374d28261f9675ce30097d1223fffd0c9438b078bf3"
+  inputs-digest = "ef5fa79273af1efa5fd584d3e779479dafffc17dcccdfb3b42c0262b342dabef"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/config/config.go
+++ b/config/config.go
@@ -59,7 +59,7 @@ type RouteInfo struct {
 // Used to map header keys pulled from elasticbeanstalk env to header names expected by
 // destinations proxied to
 type AddHeader struct {
-	DestinationHeaderKey string `json:"destination-header-key"`
+	DestinationHeaderKey string `json:"dest-header-key"`
 	EnvVarKey            string `json:"env-var-key"`
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -49,11 +49,13 @@ type RouteInfo struct {
 	// A special group, `*`, may be specified which allows any authenticated
 	// user.
 	AllowedDomainGroups []string `json:"allowed-domain-groups"`
+	AllowedOrigins      []string `json:"allowed-origins"`
 
 	// Any headers we want the auth proxy to add for us, independent of any client-supplied headers
 	// that are copied over
 	// Note that these must match env vars set in adminAuthProxy on elasticbeanstalk, where the values are stored
-	ToAddHeaders []*ToAddHeader `json:"to-add-headers"`
+	ToAddHeaders                []*ToAddHeader `json:"to-add-headers"`
+	ShareCookieAcrossSubdomains bool           `json:"share-cookie-across-subdomains"`
 }
 
 // Used to map header keys pulled from elasticbeanstalk env to header names expected by

--- a/config/config.go
+++ b/config/config.go
@@ -145,14 +145,19 @@ func (i *Info) Scheme() string {
 	return "http"
 }
 
-// initRoute initializes a RouteInfo by parsing and validating its contents.
-func initRoute(r *RouteInfo) error {
+// InitRoute initializes a RouteInfo by parsing and validating its contents.
+func InitRoute(r *RouteInfo) error {
 	toURL, err := url.Parse(r.To)
 	if err != nil {
 		return err
 	}
 
 	r.toURL = toURL
+
+	if err := initToAddHeaders(r); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -164,7 +169,7 @@ func initFromEnvVar(varName string, target *string) {
 	}
 }
 
-func InitToAddHeaders(r *RouteInfo) error {
+func initToAddHeaders(r *RouteInfo) error {
 	headers := r.ToAddHeaders
 
 	for _, headerSet := range headers {
@@ -202,14 +207,10 @@ func initInfo(n *Info) error {
 	}
 
 	for _, route := range n.Routes {
-		if err := initRoute(route); err != nil {
+		if err := InitRoute(route); err != nil {
 			return fmt.Errorf("Route %s has invalid To URL: %s",
 				route.From,
 				err)
-		}
-
-		if err := InitToAddHeaders(route); err != nil {
-			return err
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -164,7 +164,7 @@ func initFromEnvVar(varName string, target *string) {
 	}
 }
 
-func initToAddHeaders(r *RouteInfo) error {
+func InitToAddHeaders(r *RouteInfo) error {
 	headers := r.ToAddHeaders
 
 	for _, headerSet := range headers {
@@ -208,7 +208,7 @@ func initInfo(n *Info) error {
 				err)
 		}
 
-		if err := initToAddHeaders(route); err != nil {
+		if err := InitToAddHeaders(route); err != nil {
 			return err
 		}
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -166,15 +166,19 @@ func initFromEnvVar(varName string, target *string) {
 
 func initToAddHeaders(r *RouteInfo) error {
 	headers := r.ToAddHeaders
+
 	for _, headerSet := range headers {
 		headerVal := os.Getenv(headerSet.EnvVarName)
 
 		if headerVal == "" {
-			panic("value missing for required %s ENV VAR: %s:", r.From, headerSet.EnvVarName)
+			msg := fmt.Sprintf("value missing for required %s ENV VAR: %s:", r.From, headerSet.EnvVarName)
+			return errors.New(msg)
 		}
 
-		r.DestHeaderVal = headerVal
+		headerSet.DestHeaderVal = headerVal
 	}
+
+	return nil
 }
 
 func initInfo(n *Info) error {

--- a/config/config.go
+++ b/config/config.go
@@ -53,7 +53,7 @@ type RouteInfo struct {
 	// Any headers we want the auth proxy to add for us, independent of any client-supplied headers
 	// that are copied over
 	// Note that these must match env vars set in adminAuthProxy on elasticbeanstalk, where the values are stored
-	ToAddHeaders []ToAddHeader `json:"to-add-headers"`
+	ToAddHeaders []*ToAddHeader `json:"to-add-headers"`
 }
 
 // Used to map header keys pulled from elasticbeanstalk env to header names expected by
@@ -208,7 +208,9 @@ func initInfo(n *Info) error {
 				err)
 		}
 
-		initToAddHeaders(route)
+		if err := initToAddHeaders(route); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -36,6 +36,11 @@ type RouteInfo struct {
 	// request path as per RFC 3986 Section 5.2.
 	To string
 
+	// Any headers we want the auth proxy to add for us, independent of any client-supplied headers
+	// that are copied over
+	// Note that these must match env vars set in adminAuthProxy on elasticbeanstalk, where the values are stored
+	ToAddHeaders []AddHeader `json:"to-add-headers"`
+
 	toURL *url.URL
 
 	// A list of groups which may access this route.  If groups are configured,
@@ -49,6 +54,13 @@ type RouteInfo struct {
 	// A special group, `*`, may be specified which allows any authenticated
 	// user.
 	AllowedDomainGroups []string `json:"allowed-domain-groups"`
+}
+
+// Used to map header keys pulled from elasticbeanstalk env to header names expected by
+// destinations proxied to
+type AddHeader struct {
+	DestinationHeaderKey string `json:"destination-header-key"`
+	EnvVarKey            string `json:"env-var-key"`
 }
 
 // ToURL ...

--- a/config/context_test.go
+++ b/config/context_test.go
@@ -110,6 +110,8 @@ func TestInitToAddHeaders(t *testing.T) {
 
 func TestInitToAddHeadersBadEnv(t *testing.T) {
 	envVarName := "TEST_SERVICE_TOKEN"
+	os.Setenv(envVarName, "")
+
 	header := &ToAddHeader{
 		EnvVarName:    envVarName,
 		DestHeaderKey: "Authorization",

--- a/config/context_test.go
+++ b/config/context_test.go
@@ -103,7 +103,7 @@ func TestInitToAddHeaders(t *testing.T) {
 	expectedVal := "secure-token-for-test-service"
 	os.Setenv(envName, expectedVal)
 
-	err := initToAddHeaders(ri)
+	err := InitToAddHeaders(ri)
 	assert.Nil(t, err)
 	assert.Equal(t, expectedVal, ri.ToAddHeaders[0].DestHeaderVal)
 }

--- a/config/context_test.go
+++ b/config/context_test.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type userMemberOfAnyTest struct {
@@ -79,6 +82,30 @@ func TestDomainMemberOfAny(t *testing.T) {
 				test.Expected)
 		}
 	}
+}
+
+func TestInitToAddHeaders(t *testing.T) {
+	envName := "TEST_SERVICE_TOKEN"
+	header := &ToAddHeader{
+		EnvVarName:    envName,
+		DestHeaderKey: "Authorization",
+		DestHeaderVal: "",
+	}
+
+	toAddHeaders := []*ToAddHeader{header}
+
+	ri := &RouteInfo{
+		From:         "here",
+		To:           "there",
+		ToAddHeaders: toAddHeaders,
+	}
+
+	expectedVal := "secure-token-for-test-service"
+	os.Setenv(envName, expectedVal)
+
+	err := initToAddHeaders(ri)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedVal, ri.ToAddHeaders[0].DestHeaderVal)
 }
 
 func TestDomainMemberOfAnyWithNoAllowedDomainGroups(t *testing.T) {

--- a/config/context_test.go
+++ b/config/context_test.go
@@ -85,9 +85,9 @@ func TestDomainMemberOfAny(t *testing.T) {
 }
 
 func TestInitToAddHeaders(t *testing.T) {
-	envName := "TEST_SERVICE_TOKEN"
+	envVarName := "TEST_SERVICE_TOKEN"
 	header := &ToAddHeader{
-		EnvVarName:    envName,
+		EnvVarName:    envVarName,
 		DestHeaderKey: "Authorization",
 		DestHeaderVal: "",
 	}
@@ -101,10 +101,37 @@ func TestInitToAddHeaders(t *testing.T) {
 	}
 
 	expectedVal := "secure-token-for-test-service"
-	os.Setenv(envName, expectedVal)
+	os.Setenv(envVarName, expectedVal)
 
-	err := InitToAddHeaders(ri)
+	err := initToAddHeaders(ri)
 	assert.Nil(t, err)
+	assert.Equal(t, expectedVal, ri.ToAddHeaders[0].DestHeaderVal)
+}
+
+func TestInitToAddHeadersBadEnv(t *testing.T) {
+	envVarName := "TEST_SERVICE_TOKEN"
+	header := &ToAddHeader{
+		EnvVarName:    envVarName,
+		DestHeaderKey: "Authorization",
+		DestHeaderVal: "",
+	}
+
+	toAddHeaders := []*ToAddHeader{header}
+
+	ri := &RouteInfo{
+		From:         "here",
+		To:           "there",
+		ToAddHeaders: toAddHeaders,
+	}
+
+	setVal := "secure-token-for-test-service"
+	badEnvVarName := "BAD_ENV"
+	os.Setenv(badEnvVarName, setVal)
+
+	err := initToAddHeaders(ri)
+	assert.NotNil(t, err)
+
+	expectedVal := ""
 	assert.Equal(t, expectedVal, ri.ToAddHeaders[0].DestHeaderVal)
 }
 

--- a/examples/underpants.groups.json
+++ b/examples/underpants.groups.json
@@ -29,6 +29,6 @@
       "from"           : "sensitive.company.com",
       "to"             : "http://localhost:8081",
       "allowed-groups" : ["supersecret"]
-    },
+    }
   ]
 }

--- a/hub/hub.go
+++ b/hub/hub.go
@@ -60,7 +60,7 @@ func Setup(ctx *config.Context, prv auth.Provider, mb *mux.Builder) {
 					panic(err)
 				}
 
-				http.SetCookie(w, user.CreateCookie(v, ctx.HasCerts()))
+				http.SetCookie(w, user.CreateCookie(v, ctx, r))
 
 				p := back.Path
 				if back.RawQuery != "" {

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -76,6 +76,11 @@ func (b *Backend) serveHTTPProxy(w http.ResponseWriter, r *http.Request) {
 		zap.String("method", r.Method),
 	}
 
+	// for admin dashboard xhr requests
+	w.Header().Add("Access-Control-Allow-Origin", b.Route.To)
+	w.Header().Add("Access-Control-Allow-Headers", "*")
+	w.Header().Set("Access-Control-Allow-Credentials", "true")
+
 	u, err := user.DecodeFromRequest(r, b.Ctx.Key)
 	if err != nil {
 		zap.L().Info("authentication required. redirecting to auth provider", logFields...)

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -34,28 +34,11 @@ func copyHeaders(dst, src http.Header) {
 	}
 }
 
-func addToAddHeaders(dst http.Header, headerSets []AddHeader) {
-	for _, headerKeySet := range headerSets {
-		envKey := headerKeySet.EnvVarKey
-
-		if envKey == "" {
-			err := fmt.Sprintf("cannot have empty value for env-var-key")
-			panic(err)
-		}
-
-		headerVal := os.Getenv(envKey)
-		if headerVal == "" {
-			err := fmt.Sprintf("cannot have empty value for header in config: %s", headerKey)
-			panic(err)
-		}
-
-		destHeader := headerKeySet.DestinationHeaderKey
-		if destHeader == "" {
-			err := fmt.Sprintf("cannot have empty value for dest-header-key")
-			panic(err)
-		}
-
-		dst.Add(destHeader, headerVal)
+func addToAddHeaders(dst http.Header, toAddHeaders []ToAddHeader) {
+	for _, toAddHeader := range toAddHeaders {
+		headerVal := toAddHeader.DestHeaderVal
+		headerKey := toAddHeader.DestHeaderKey
+		dst.Add(headerKey, headerVal)
 	}
 }
 

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -36,8 +37,8 @@ func copyHeaders(dst, src http.Header) {
 
 func addToAddHeaders(dst http.Header, toAddHeaders []config.ToAddHeader) {
 	for _, toAddHeader := range toAddHeaders {
-		headerVal := toAddHeader.DestHeaderVal
 		headerKey := toAddHeader.DestHeaderKey
+		headerVal := toAddHeader.DestHeaderVal
 		dst.Add(headerKey, headerVal)
 	}
 }

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -34,7 +34,7 @@ func copyHeaders(dst, src http.Header) {
 	}
 }
 
-func addToAddHeaders(dst http.Header, toAddHeaders []ToAddHeader) {
+func addToAddHeaders(dst http.Header, toAddHeaders []config.ToAddHeader) {
 	for _, toAddHeader := range toAddHeaders {
 		headerVal := toAddHeader.DestHeaderVal
 		headerKey := toAddHeader.DestHeaderKey
@@ -70,7 +70,6 @@ func (b *Backend) serveHTTPAuth(w http.ResponseWriter, r *http.Request) {
 func (b *Backend) serveHTTPProxy(w http.ResponseWriter, r *http.Request) {
 	logFields := []zap.Field{
 		zap.String("from", b.Route.From),
-		zap.String("to-add-headers", b.Route.ToAddHeaders),
 		zap.String("uri", r.RequestURI),
 		zap.String("method", r.Method),
 	}

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -146,7 +146,7 @@ func (b *Backend) serveHTTPProxy(w http.ResponseWriter, r *http.Request) {
 	// Headers we want to add during the proxy in addition to any client-supplied headers
 	// e.g. sensitive auth tokens that we do not want stored in client-side dashboards
 	if len(b.Route.ToAddHeaders) > 0 {
-		addToAddHeaders(br, b.Route.ToAddHeaders)
+		addToAddHeaders(br.Header, b.Route.ToAddHeaders)
 	}
 
 	// User information is passed to backends as headers.

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -84,6 +84,10 @@ func (b *Backend) serveHTTPProxy(w http.ResponseWriter, r *http.Request) {
 	}
 	logFields = append(logFields, zap.String("user", u.Email))
 
+	b.proxyUserRequest(w, r, u, logFields)
+}
+
+func (b *Backend) proxyUserRequest(w http.ResponseWriter, r *http.Request, u *user.Info, logFields []zap.Field) {
 	if !b.Ctx.UserMemberOfAny(u.Email, b.Route.AllowedGroups) {
 		msg := "Forbidden: you are not a member of a group authorized to view this site."
 		zap.L().Info(msg, logFields...)

--- a/proxy/backend.go
+++ b/proxy/backend.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -35,11 +34,13 @@ func copyHeaders(dst, src http.Header) {
 	}
 }
 
-func addToAddHeaders(dst http.Header, toAddHeaders []config.ToAddHeader) {
-	for _, toAddHeader := range toAddHeaders {
-		headerKey := toAddHeader.DestHeaderKey
-		headerVal := toAddHeader.DestHeaderVal
-		dst.Add(headerKey, headerVal)
+func addToAddHeaders(dst http.Header, toAddHeaders []*config.ToAddHeader) {
+	if len(toAddHeaders) > 0 {
+		for _, toAddHeader := range toAddHeaders {
+			headerKey := toAddHeader.DestHeaderKey
+			headerVal := toAddHeader.DestHeaderVal
+			dst.Add(headerKey, headerVal)
+		}
 	}
 }
 
@@ -128,9 +129,8 @@ func (b *Backend) serveHTTPProxy(w http.ResponseWriter, r *http.Request) {
 
 	// Headers we want to add during the proxy in addition to any client-supplied headers
 	// e.g. sensitive auth tokens that we do not want stored in client-side dashboards
-	if len(b.Route.ToAddHeaders) > 0 {
-		addToAddHeaders(br.Header, b.Route.ToAddHeaders)
-	}
+
+	addToAddHeaders(br.Header, b.Route.ToAddHeaders)
 
 	// User information is passed to backends as headers.
 	br.Header.Add("Underpants-Email", url.QueryEscape(u.Email))

--- a/proxy/backend_test.go
+++ b/proxy/backend_test.go
@@ -1,0 +1,66 @@
+package proxy
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/playdots/underpants/auth"
+	"github.com/playdots/underpants/auth/google"
+	"github.com/playdots/underpants/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddToAddHeaders(t *testing.T) {
+	ctx := &config.Context{
+		Info: &config.Info{
+			Oauth: config.OAuthInfo{
+				ClientID:     "client_id",
+				ClientSecret: "client_secret",
+			},
+			Host: "localhost",
+		},
+		Port: 5000,
+	}
+
+	envName := "TEST_SERVICE_TOKEN"
+	header := &config.ToAddHeader{
+		EnvVarName:    envName,
+		DestHeaderKey: "Authorization",
+		DestHeaderVal: "",
+	}
+
+	toAddHeaders := []*config.ToAddHeader{header}
+	ri := &config.RouteInfo{
+		From:         "here",
+		To:           "there",
+		ToAddHeaders: toAddHeaders,
+	}
+
+	expectedVal := "secure-token-for-test-service"
+	os.Setenv(envName, expectedVal)
+
+	var prv auth.Provider
+	prv = google.Provider
+
+	b := &Backend{
+		Ctx:          ctx,
+		Route:        ri,
+		AuthProvider: prv,
+	}
+
+	err := config.InitToAddHeaders(ri)
+	assert.Nil(t, err)
+	assert.Equal(t, expectedVal, ri.ToAddHeaders[0].DestHeaderVal)
+
+	r, _ := http.NewRequest("GET", "localhost", nil)
+	addToAddHeaders(r.Header, b.Route.ToAddHeaders)
+
+	for key, vals := range r.Header {
+		for _, val := range vals {
+			if key == "Authorization" {
+				assert.Equal(t, expectedVal, val)
+			}
+		}
+	}
+}

--- a/proxy/test.json
+++ b/proxy/test.json
@@ -1,0 +1,11 @@
+{
+  "host" : "expected-email-host.com",
+  "oauth" : {
+    "provider"      : "google",
+    "domain"        : "expected-email-host.com",
+    "client-id"     : "client-id",
+    "client-secret" : "secret"
+  },
+  "use-https":true,
+  "use-strict-security-headers": true
+}


### PR DESCRIPTION
We may want to let the proxy add headers to requests that weren't added to the requests by the originating source. For example, one may want to add auth tokens to requests sent from admin dashboards, without exposing those tokens in the client code.

Also see: https://github.com/playdots/underpants-eb/pull/22

Edit: to make JS requests across subdomains, we need to modify cookies returned from auth proxy to exclude subdomains for allowed origins and only include the naked domain. 

See underpants-eb modified underpants.json which includes a new `share-cookie-across-subdomains` field for certain domains that we want to share cross-subdomain cookies with clients that make requests to them. For example, campaigns.dotshq.com will share cross-subdomain cookies with campaigns-web.dotshq.com, and campaigns.dotshq.com has campaigns-web listed as an allowed origin.