### PR TITLE
use env var to determine filename

### DIFF
--- a/underpants.go
+++ b/underpants.go
@@ -200,7 +200,9 @@ func setupLogger() error {
 
 func main() {
 	flagPort := flag.Int("port", 0, "")
-	flagConf := flag.String("conf", "underpants.json", "")
+
+	confFileName := os.Getenv("UNDERPANTS_CONF_JSON_FILENAME")
+	flagConf := flag.String("conf", confFileName, "")
 
 	flag.Parse()
 


### PR DESCRIPTION
* Use UNDERPANTS_CONF_JSON_FILENAME env var to specify filename by environment (underpants.json for prod, underpants-dev.json for local dev)
* Will require an env var addition to beanstalk config for underpants-eb (UNDERPANTS_CONF_JSON_FILENAME=underpants.json)